### PR TITLE
Improve iframe display for component previews

### DIFF
--- a/scripts/generate-meta.js
+++ b/scripts/generate-meta.js
@@ -1,0 +1,103 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+const ROOT = path.resolve("src/components");
+
+const ACRONYMS = new Map([
+  ["ui", "UI"],
+  ["faq", "FAQ"],
+  ["cta", "CTA"],
+  ["api", "API"],
+  ["id", "ID"],
+  ["pdf", "PDF"],
+]);
+
+function toTitleSegment(segment) {
+  const words = segment.split(/[-_]+/).filter(Boolean);
+  if (words.length === 0) return "";
+  return words
+    .map((word) => {
+      const lower = word.toLowerCase();
+      if (ACRONYMS.has(lower)) return ACRONYMS.get(lower);
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join(" ");
+}
+
+function toLabel(base) {
+  return toTitleSegment(base);
+}
+
+function toId(base) {
+  return base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+async function ensureMeta(dir) {
+  const metaPath = path.join(dir, "meta.json");
+  try {
+    await fs.access(metaPath);
+    return; // already exists
+  } catch (err) {
+    // ignore
+  }
+
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const htmlFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".html"))
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b));
+
+  if (htmlFiles.length === 0) {
+    return;
+  }
+
+  const relative = path.relative(ROOT, dir);
+  if (!relative) return;
+  const segments = relative.split(path.sep).filter(Boolean);
+  if (segments.length === 0) return;
+  const [category, ...slugSegments] = segments;
+  if (!category || slugSegments.length === 0) {
+    return;
+  }
+
+  const title = slugSegments.map(toTitleSegment).join(" – ");
+  const variants = htmlFiles.map((file) => {
+    const base = file.replace(/\.html$/, "");
+    return {
+      id: toId(base),
+      label: toLabel(base),
+      file,
+    };
+  });
+
+  const meta = {
+    title,
+    slug: slugSegments.join("/"),
+    category,
+    tags: [],
+    variants,
+    props: {},
+  };
+
+  const json = JSON.stringify(meta, null, 2);
+  await fs.writeFile(metaPath, `${json}\n`, "utf8");
+  console.log(`Created ${path.relative(process.cwd(), metaPath)}`);
+}
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  await ensureMeta(dir);
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      await walk(path.join(dir, entry.name));
+    }
+  }
+}
+
+walk(ROOT).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/application-ui/application-shells/sidebar/meta.json
+++ b/src/components/application-ui/application-shells/sidebar/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Application Shells – Sidebar",
+  "slug": "application-shells/sidebar",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "brand-sidebar-with-header",
+      "label": "Brand Sidebar With Header",
+      "file": "brand_sidebar_with_header.html"
+    },
+    {
+      "id": "brand-sidebar",
+      "label": "Brand Sidebar",
+      "file": "brand_sidebar.html"
+    },
+    {
+      "id": "dark-sidebar-with-header",
+      "label": "Dark Sidebar With Header",
+      "file": "dark_sidebar_with_header.html"
+    },
+    {
+      "id": "dark-sidebar",
+      "label": "Dark Sidebar",
+      "file": "dark_sidebar.html"
+    },
+    {
+      "id": "light-sidebar-with-constrained-content-area",
+      "label": "Light Sidebar With Constrained Content Area",
+      "file": "light_sidebar_with_constrained_content_area.html"
+    },
+    {
+      "id": "light-sidebar-with-header",
+      "label": "Light Sidebar With Header",
+      "file": "light_sidebar_with_header.html"
+    },
+    {
+      "id": "light-sidebar-with-off-white-background",
+      "label": "Light Sidebar With Off White Background",
+      "file": "light_sidebar_with_off_white_background.html"
+    },
+    {
+      "id": "light-sidebar",
+      "label": "Light Sidebar",
+      "file": "light_sidebar.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/application-shells/stacked/meta.json
+++ b/src/components/application-ui/application-shells/stacked/meta.json
@@ -1,0 +1,54 @@
+{
+  "title": "Application Shells – Stacked",
+  "slug": "application-shells/stacked",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "brand-nav-with-overlap",
+      "label": "Brand Nav With Overlap",
+      "file": "brand_nav_with_overlap.html"
+    },
+    {
+      "id": "branded-nav-with-compact-white-page-header",
+      "label": "Branded Nav With Compact White Page Header",
+      "file": "branded_nav_with_compact_white_page_header.html"
+    },
+    {
+      "id": "branded-nav-with-white-page-header",
+      "label": "Branded Nav With White Page Header",
+      "file": "branded_nav_with_white_page_header.html"
+    },
+    {
+      "id": "dark-nav-with-compact-white-page-header",
+      "label": "Dark Nav With Compact White Page Header",
+      "file": "dark_nav_with_compact_white_page_header.html"
+    },
+    {
+      "id": "dark-nav-with-overlap",
+      "label": "Dark Nav With Overlap",
+      "file": "dark_nav_with_overlap.html"
+    },
+    {
+      "id": "dark-nav-with-white-page-header",
+      "label": "Dark Nav With White Page Header",
+      "file": "dark_nav_with_white_page_header.html"
+    },
+    {
+      "id": "light-nav-on-gray-background",
+      "label": "Light Nav On Gray Background",
+      "file": "light_nav_on_gray_background.html"
+    },
+    {
+      "id": "light-nav-with-bottom-border",
+      "label": "Light Nav With Bottom Border",
+      "file": "light_nav_with_bottom_border.html"
+    },
+    {
+      "id": "two-row-navigation-with-overlap",
+      "label": "Two Row Navigation With Overlap",
+      "file": "two_row_navigation_with_overlap.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/data-display/calendars/meta.json
+++ b/src/components/application-ui/data-display/calendars/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Data Display – Calendars",
+  "slug": "data-display/calendars",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "borderless-side-by-side",
+      "label": "Borderless Side By Side",
+      "file": "borderless_side_by_side.html"
+    },
+    {
+      "id": "borderless-stacked",
+      "label": "Borderless Stacked",
+      "file": "borderless_stacked.html"
+    },
+    {
+      "id": "day-view",
+      "label": "Day View",
+      "file": "day_view.html"
+    },
+    {
+      "id": "double",
+      "label": "Double",
+      "file": "double.html"
+    },
+    {
+      "id": "month-view",
+      "label": "Month View",
+      "file": "month_view.html"
+    },
+    {
+      "id": "small-with-meetings",
+      "label": "Small With Meetings",
+      "file": "small_with_meetings.html"
+    },
+    {
+      "id": "week-view",
+      "label": "Week View",
+      "file": "week_view.html"
+    },
+    {
+      "id": "year-view",
+      "label": "Year View",
+      "file": "year_view.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/data-display/description-lists/meta.json
+++ b/src/components/application-ui/data-display/description-lists/meta.json
@@ -1,0 +1,44 @@
+{
+  "title": "Data Display – Description Lists",
+  "slug": "data-display/description-lists",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "left-aligned-in-card",
+      "label": "Left Aligned In Card",
+      "file": "left_aligned_in_card.html"
+    },
+    {
+      "id": "left-aligned-on-dark",
+      "label": "Left Aligned On Dark",
+      "file": "left_aligned_on_dark.html"
+    },
+    {
+      "id": "left-aligned-striped",
+      "label": "Left Aligned Striped",
+      "file": "left_aligned_striped.html"
+    },
+    {
+      "id": "left-aligned-with-inline-actions",
+      "label": "Left Aligned With Inline Actions",
+      "file": "left_aligned_with_inline_actions.html"
+    },
+    {
+      "id": "left-aligned",
+      "label": "Left Aligned",
+      "file": "left_aligned.html"
+    },
+    {
+      "id": "narrow-with-hidden-labels",
+      "label": "Narrow With Hidden Labels",
+      "file": "narrow_with_hidden_labels.html"
+    },
+    {
+      "id": "two-column",
+      "label": "Two Column",
+      "file": "two_column.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/data-display/stats/meta.json
+++ b/src/components/application-ui/data-display/stats/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Data Display – Stats",
+  "slug": "data-display/stats",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-in-cards",
+      "label": "Simple In Cards",
+      "file": "simple_in_cards.html"
+    },
+    {
+      "id": "simple-on-dark",
+      "label": "Simple On Dark",
+      "file": "simple_on_dark.html"
+    },
+    {
+      "id": "with-brand-icon",
+      "label": "With Brand Icon",
+      "file": "with_brand_icon.html"
+    },
+    {
+      "id": "with-shared-borders",
+      "label": "With Shared Borders",
+      "file": "with_shared_borders.html"
+    },
+    {
+      "id": "with-trending",
+      "label": "With Trending",
+      "file": "with_trending.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/elements/avatars/meta.json
+++ b/src/components/application-ui/elements/avatars/meta.json
@@ -1,0 +1,64 @@
+{
+  "title": "Elements – Avatars",
+  "slug": "elements/avatars",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "avatar-group-stacked-bottom-to-top",
+      "label": "Avatar Group Stacked Bottom To Top",
+      "file": "avatar_group_stacked_bottom_to_top.html"
+    },
+    {
+      "id": "avatar-group-stacked-top-to-bottom",
+      "label": "Avatar Group Stacked Top To Bottom",
+      "file": "avatar_group_stacked_top_to_bottom.html"
+    },
+    {
+      "id": "circular-avatars-with-bottom-notification",
+      "label": "Circular Avatars With Bottom Notification",
+      "file": "circular_avatars_with_bottom_notification.html"
+    },
+    {
+      "id": "circular-avatars-with-placeholder-icon",
+      "label": "Circular Avatars With Placeholder Icon",
+      "file": "circular_avatars_with_placeholder_icon.html"
+    },
+    {
+      "id": "circular-avatars-with-placeholder-initials",
+      "label": "Circular Avatars With Placeholder Initials",
+      "file": "circular_avatars_with_placeholder_initials.html"
+    },
+    {
+      "id": "circular-avatars-with-top-notification",
+      "label": "Circular Avatars With Top Notification",
+      "file": "circular_avatars_with_top_notification.html"
+    },
+    {
+      "id": "circular-avatars",
+      "label": "Circular Avatars",
+      "file": "circular_avatars.html"
+    },
+    {
+      "id": "rounded-avatars-with-bottom-notification",
+      "label": "Rounded Avatars With Bottom Notification",
+      "file": "rounded_avatars_with_bottom_notification.html"
+    },
+    {
+      "id": "rounded-avatars-with-top-notification",
+      "label": "Rounded Avatars With Top Notification",
+      "file": "rounded_avatars_with_top_notification.html"
+    },
+    {
+      "id": "rounded-avatars",
+      "label": "Rounded Avatars",
+      "file": "rounded_avatars.html"
+    },
+    {
+      "id": "with-text",
+      "label": "With Text",
+      "file": "with_text.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/elements/badges/meta.json
+++ b/src/components/application-ui/elements/badges/meta.json
@@ -1,0 +1,99 @@
+{
+  "title": "Elements – Badges",
+  "slug": "elements/badges",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "flat-pill-with-dot",
+      "label": "Flat Pill With Dot",
+      "file": "flat_pill_with_dot.html"
+    },
+    {
+      "id": "flat-pill",
+      "label": "Flat Pill",
+      "file": "flat_pill.html"
+    },
+    {
+      "id": "flat-with-dot",
+      "label": "Flat With Dot",
+      "file": "flat_with_dot.html"
+    },
+    {
+      "id": "flat-with-remove-button",
+      "label": "Flat With Remove Button",
+      "file": "flat_with_remove_button.html"
+    },
+    {
+      "id": "flat",
+      "label": "Flat",
+      "file": "flat.html"
+    },
+    {
+      "id": "pill-with-border-and-dot",
+      "label": "Pill With Border And Dot",
+      "file": "pill_with_border_and_dot.html"
+    },
+    {
+      "id": "pill-with-border",
+      "label": "Pill With Border",
+      "file": "pill_with_border.html"
+    },
+    {
+      "id": "small-flat-pill-with-dot",
+      "label": "Small Flat Pill With Dot",
+      "file": "small_flat_pill_with_dot.html"
+    },
+    {
+      "id": "small-flat-pill",
+      "label": "Small Flat Pill",
+      "file": "small_flat_pill.html"
+    },
+    {
+      "id": "small-flat-with-dot",
+      "label": "Small Flat With Dot",
+      "file": "small_flat_with_dot.html"
+    },
+    {
+      "id": "small-flat",
+      "label": "Small Flat",
+      "file": "small_flat.html"
+    },
+    {
+      "id": "small-pill-with-border",
+      "label": "Small Pill With Border",
+      "file": "small_pill_with_border.html"
+    },
+    {
+      "id": "small-with-border",
+      "label": "Small With Border",
+      "file": "small_with_border.html"
+    },
+    {
+      "id": "with-border-and-dot-on-dark",
+      "label": "With Border And Dot On Dark",
+      "file": "with_border_and_dot_on_dark.html"
+    },
+    {
+      "id": "with-border-and-dot",
+      "label": "With Border And Dot",
+      "file": "with_border_and_dot.html"
+    },
+    {
+      "id": "with-border-and-remove-button",
+      "label": "With Border And Remove Button",
+      "file": "with_border_and_remove_button.html"
+    },
+    {
+      "id": "with-border-on-dark",
+      "label": "With Border On Dark",
+      "file": "with_border_on_dark.html"
+    },
+    {
+      "id": "with-border",
+      "label": "With Border",
+      "file": "with_border.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/elements/button-groups/meta.json
+++ b/src/components/application-ui/elements/button-groups/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Elements – Button Groups",
+  "slug": "elements/button-groups",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "basic",
+      "label": "Basic",
+      "file": "basic.html"
+    },
+    {
+      "id": "icon-only",
+      "label": "Icon Only",
+      "file": "icon_only.html"
+    },
+    {
+      "id": "with-checkbox-and-dropdown",
+      "label": "With Checkbox And Dropdown",
+      "file": "with_checkbox_and_dropdown.html"
+    },
+    {
+      "id": "with-dropdown",
+      "label": "With Dropdown",
+      "file": "with_dropdown.html"
+    },
+    {
+      "id": "with-stat",
+      "label": "With Stat",
+      "file": "with_stat.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/elements/buttons/meta.json
+++ b/src/components/application-ui/elements/buttons/meta.json
@@ -1,0 +1,59 @@
+{
+  "title": "Elements – Buttons",
+  "slug": "elements/buttons",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "buttons-with-leading-icon",
+      "label": "Buttons With Leading Icon",
+      "file": "buttons_with_leading_icon.html"
+    },
+    {
+      "id": "buttons-with-trailing-icon",
+      "label": "Buttons With Trailing Icon",
+      "file": "buttons_with_trailing_icon.html"
+    },
+    {
+      "id": "circular-buttons",
+      "label": "Circular Buttons",
+      "file": "circular_buttons.html"
+    },
+    {
+      "id": "primary-buttons-on-dark",
+      "label": "Primary Buttons On Dark",
+      "file": "primary_buttons_on_dark.html"
+    },
+    {
+      "id": "primary-buttons",
+      "label": "Primary Buttons",
+      "file": "primary_buttons.html"
+    },
+    {
+      "id": "rounded-primary-buttons",
+      "label": "Rounded Primary Buttons",
+      "file": "rounded_primary_buttons.html"
+    },
+    {
+      "id": "rounded-secondary-buttons",
+      "label": "Rounded Secondary Buttons",
+      "file": "rounded_secondary_buttons.html"
+    },
+    {
+      "id": "secondary-buttons-on-dark",
+      "label": "Secondary Buttons On Dark",
+      "file": "secondary_buttons_on_dark.html"
+    },
+    {
+      "id": "secondary-buttons",
+      "label": "Secondary Buttons",
+      "file": "secondary_buttons.html"
+    },
+    {
+      "id": "soft-buttons",
+      "label": "Soft Buttons",
+      "file": "soft_buttons.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/elements/dropdowns/meta.json
+++ b/src/components/application-ui/elements/dropdowns/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Elements – Dropdowns",
+  "slug": "elements/dropdowns",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-dividers",
+      "label": "With Dividers",
+      "file": "with_dividers.html"
+    },
+    {
+      "id": "with-icons",
+      "label": "With Icons",
+      "file": "with_icons.html"
+    },
+    {
+      "id": "with-minimal-menu-icon",
+      "label": "With Minimal Menu Icon",
+      "file": "with_minimal_menu_icon.html"
+    },
+    {
+      "id": "with-simple-header",
+      "label": "With Simple Header",
+      "file": "with_simple_header.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/feedback/alerts/meta.json
+++ b/src/components/application-ui/feedback/alerts/meta.json
@@ -1,0 +1,39 @@
+{
+  "title": "Feedback – Alerts",
+  "slug": "feedback/alerts",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-accent-border",
+      "label": "With Accent Border",
+      "file": "with_accent_border.html"
+    },
+    {
+      "id": "with-actions",
+      "label": "With Actions",
+      "file": "with_actions.html"
+    },
+    {
+      "id": "with-description",
+      "label": "With Description",
+      "file": "with_description.html"
+    },
+    {
+      "id": "with-dismiss-button",
+      "label": "With Dismiss Button",
+      "file": "with_dismiss_button.html"
+    },
+    {
+      "id": "with-link-on-right",
+      "label": "With Link On Right",
+      "file": "with_link_on_right.html"
+    },
+    {
+      "id": "with-list",
+      "label": "With List",
+      "file": "with_list.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/feedback/empty-states/meta.json
+++ b/src/components/application-ui/feedback/empty-states/meta.json
@@ -1,0 +1,39 @@
+{
+  "title": "Feedback – Empty States",
+  "slug": "feedback/empty-states",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-dashed-border",
+      "label": "With Dashed Border",
+      "file": "with_dashed_border.html"
+    },
+    {
+      "id": "with-recommendations-grid",
+      "label": "With Recommendations Grid",
+      "file": "with_recommendations_grid.html"
+    },
+    {
+      "id": "with-recommendations",
+      "label": "With Recommendations",
+      "file": "with_recommendations.html"
+    },
+    {
+      "id": "with-starting-points",
+      "label": "With Starting Points",
+      "file": "with_starting_points.html"
+    },
+    {
+      "id": "with-templates",
+      "label": "With Templates",
+      "file": "with_templates.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/action-panels/meta.json
+++ b/src/components/application-ui/forms/action-panels/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Forms – Action Panels",
+  "slug": "forms/action-panels",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-well",
+      "label": "Simple Well",
+      "file": "simple_well.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-button-at-top-right",
+      "label": "With Button At Top Right",
+      "file": "with_button_at_top_right.html"
+    },
+    {
+      "id": "with-button-on-right",
+      "label": "With Button On Right",
+      "file": "with_button_on_right.html"
+    },
+    {
+      "id": "with-input",
+      "label": "With Input",
+      "file": "with_input.html"
+    },
+    {
+      "id": "with-link",
+      "label": "With Link",
+      "file": "with_link.html"
+    },
+    {
+      "id": "with-toggle",
+      "label": "With Toggle",
+      "file": "with_toggle.html"
+    },
+    {
+      "id": "with-well",
+      "label": "With Well",
+      "file": "with_well.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/checkboxes/meta.json
+++ b/src/components/application-ui/forms/checkboxes/meta.json
@@ -1,0 +1,29 @@
+{
+  "title": "Forms – Checkboxes",
+  "slug": "forms/checkboxes",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "list-with-checkbox-on-right",
+      "label": "List With Checkbox On Right",
+      "file": "list_with_checkbox_on_right.html"
+    },
+    {
+      "id": "list-with-description",
+      "label": "List With Description",
+      "file": "list_with_description.html"
+    },
+    {
+      "id": "list-with-inline-description",
+      "label": "List With Inline Description",
+      "file": "list_with_inline_description.html"
+    },
+    {
+      "id": "simple-list-with-heading",
+      "label": "Simple List With Heading",
+      "file": "simple_list_with_heading.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/comboboxes/meta.json
+++ b/src/components/application-ui/forms/comboboxes/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Forms – Comboboxes",
+  "slug": "forms/comboboxes",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-check-on-left",
+      "label": "With Check On Left",
+      "file": "with_check_on_left.html"
+    },
+    {
+      "id": "with-image",
+      "label": "With Image",
+      "file": "with_image.html"
+    },
+    {
+      "id": "with-secondary-text",
+      "label": "With Secondary Text",
+      "file": "with_secondary_text.html"
+    },
+    {
+      "id": "with-status-indicator",
+      "label": "With Status Indicator",
+      "file": "with_status_indicator.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/form-layouts/meta.json
+++ b/src/components/application-ui/forms/form-layouts/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Forms – Form Layouts",
+  "slug": "forms/form-layouts",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "labels-on-left",
+      "label": "Labels On Left",
+      "file": "labels_on_left.html"
+    },
+    {
+      "id": "stacked-on-dark",
+      "label": "Stacked On Dark",
+      "file": "stacked_on_dark.html"
+    },
+    {
+      "id": "stacked",
+      "label": "Stacked",
+      "file": "stacked.html"
+    },
+    {
+      "id": "two-column-with-cards",
+      "label": "Two Column With Cards",
+      "file": "two_column_with_cards.html"
+    },
+    {
+      "id": "two-column",
+      "label": "Two Column",
+      "file": "two_column.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/input-groups/meta.json
+++ b/src/components/application-ui/forms/input-groups/meta.json
@@ -1,0 +1,114 @@
+{
+  "title": "Forms – Input Groups",
+  "slug": "forms/input-groups",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "input-with-add-on",
+      "label": "Input With Add On",
+      "file": "input_with_add_on.html"
+    },
+    {
+      "id": "input-with-corner-hint",
+      "label": "Input With Corner Hint",
+      "file": "input_with_corner_hint.html"
+    },
+    {
+      "id": "input-with-disabled-state",
+      "label": "Input With Disabled State",
+      "file": "input_with_disabled_state.html"
+    },
+    {
+      "id": "input-with-gray-background-and-bottom-border",
+      "label": "Input With Gray Background And Bottom Border",
+      "file": "input_with_gray_background_and_bottom_border.html"
+    },
+    {
+      "id": "input-with-hidden-label",
+      "label": "Input With Hidden Label",
+      "file": "input_with_hidden_label.html"
+    },
+    {
+      "id": "input-with-inline-add-on",
+      "label": "Input With Inline Add On",
+      "file": "input_with_inline_add_on.html"
+    },
+    {
+      "id": "input-with-inline-leading-add-on-and-trailing-dropdown",
+      "label": "Input With Inline Leading Add On And Trailing Dropdown",
+      "file": "input_with_inline_leading_add_on_and_trailing_dropdown.html"
+    },
+    {
+      "id": "input-with-inline-leading-and-trailing-add-ons",
+      "label": "Input With Inline Leading And Trailing Add Ons",
+      "file": "input_with_inline_leading_and_trailing_add_ons.html"
+    },
+    {
+      "id": "input-with-inline-leading-dropdown",
+      "label": "Input With Inline Leading Dropdown",
+      "file": "input_with_inline_leading_dropdown.html"
+    },
+    {
+      "id": "input-with-inset-label",
+      "label": "Input With Inset Label",
+      "file": "input_with_inset_label.html"
+    },
+    {
+      "id": "input-with-keyboard-shortcut",
+      "label": "Input With Keyboard Shortcut",
+      "file": "input_with_keyboard_shortcut.html"
+    },
+    {
+      "id": "input-with-label-and-help-text",
+      "label": "Input With Label And Help Text",
+      "file": "input_with_label_and_help_text.html"
+    },
+    {
+      "id": "input-with-label",
+      "label": "Input With Label",
+      "file": "input_with_label.html"
+    },
+    {
+      "id": "input-with-leading-icon-and-trailing-button",
+      "label": "Input With Leading Icon And Trailing Button",
+      "file": "input_with_leading_icon_and_trailing_button.html"
+    },
+    {
+      "id": "input-with-leading-icon",
+      "label": "Input With Leading Icon",
+      "file": "input_with_leading_icon.html"
+    },
+    {
+      "id": "input-with-overlapping-label",
+      "label": "Input With Overlapping Label",
+      "file": "input_with_overlapping_label.html"
+    },
+    {
+      "id": "input-with-pill-shape",
+      "label": "Input With Pill Shape",
+      "file": "input_with_pill_shape.html"
+    },
+    {
+      "id": "input-with-trailing-icon",
+      "label": "Input With Trailing Icon",
+      "file": "input_with_trailing_icon.html"
+    },
+    {
+      "id": "input-with-validation-error",
+      "label": "Input With Validation Error",
+      "file": "input_with_validation_error.html"
+    },
+    {
+      "id": "inputs-with-inset-labels-and-shared-borders",
+      "label": "Inputs With Inset Labels And Shared Borders",
+      "file": "inputs_with_inset_labels_and_shared_borders.html"
+    },
+    {
+      "id": "inputs-with-shared-borders",
+      "label": "Inputs With Shared Borders",
+      "file": "inputs_with_shared_borders.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/radio-groups/meta.json
+++ b/src/components/application-ui/forms/radio-groups/meta.json
@@ -1,0 +1,69 @@
+{
+  "title": "Forms – Radio Groups",
+  "slug": "forms/radio-groups",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "cards",
+      "label": "Cards",
+      "file": "cards.html"
+    },
+    {
+      "id": "color-picker",
+      "label": "Color Picker",
+      "file": "color_picker.html"
+    },
+    {
+      "id": "list-with-description",
+      "label": "List With Description",
+      "file": "list_with_description.html"
+    },
+    {
+      "id": "list-with-descriptions-in-panel",
+      "label": "List With Descriptions In Panel",
+      "file": "list_with_descriptions_in_panel.html"
+    },
+    {
+      "id": "list-with-inline-description",
+      "label": "List With Inline Description",
+      "file": "list_with_inline_description.html"
+    },
+    {
+      "id": "list-with-radio-on-right",
+      "label": "List With Radio On Right",
+      "file": "list_with_radio_on_right.html"
+    },
+    {
+      "id": "simple-inline-list",
+      "label": "Simple Inline List",
+      "file": "simple_inline_list.html"
+    },
+    {
+      "id": "simple-list-with-radio-on-right",
+      "label": "Simple List With Radio On Right",
+      "file": "simple_list_with_radio_on_right.html"
+    },
+    {
+      "id": "simple-list",
+      "label": "Simple List",
+      "file": "simple_list.html"
+    },
+    {
+      "id": "simple-table",
+      "label": "Simple Table",
+      "file": "simple_table.html"
+    },
+    {
+      "id": "small-cards",
+      "label": "Small Cards",
+      "file": "small_cards.html"
+    },
+    {
+      "id": "stacked-cards",
+      "label": "Stacked Cards",
+      "file": "stacked_cards.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/select-menus/meta.json
+++ b/src/components/application-ui/forms/select-menus/meta.json
@@ -1,0 +1,44 @@
+{
+  "title": "Forms – Select Menus",
+  "slug": "forms/select-menus",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "branded-with-supported-text",
+      "label": "Branded With Supported Text",
+      "file": "branded_with_supported_text.html"
+    },
+    {
+      "id": "custom-with-avatar",
+      "label": "Custom With Avatar",
+      "file": "custom_with_avatar.html"
+    },
+    {
+      "id": "custom-with-check-on-left",
+      "label": "Custom With Check On Left",
+      "file": "custom_with_check_on_left.html"
+    },
+    {
+      "id": "custom-with-status-indicator",
+      "label": "Custom With Status Indicator",
+      "file": "custom_with_status_indicator.html"
+    },
+    {
+      "id": "simple-custom",
+      "label": "Simple Custom",
+      "file": "simple_custom.html"
+    },
+    {
+      "id": "simple-native",
+      "label": "Simple Native",
+      "file": "simple_native.html"
+    },
+    {
+      "id": "with-secondary-text",
+      "label": "With Secondary Text",
+      "file": "with_secondary_text.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/sign-in-forms/meta.json
+++ b/src/components/application-ui/forms/sign-in-forms/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Forms – Sign In Forms",
+  "slug": "forms/sign-in-forms",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-card",
+      "label": "Simple Card",
+      "file": "simple_card.html"
+    },
+    {
+      "id": "simple-no-labels",
+      "label": "Simple No Labels",
+      "file": "simple_no_labels.html"
+    },
+    {
+      "id": "simple-on-dark",
+      "label": "Simple On Dark",
+      "file": "simple_on_dark.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "split-screen",
+      "label": "Split Screen",
+      "file": "split_screen.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/textareas/meta.json
+++ b/src/components/application-ui/forms/textareas/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Forms – Textareas",
+  "slug": "forms/textareas",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-avatar-and-actions",
+      "label": "With Avatar And Actions",
+      "file": "with_avatar_and_actions.html"
+    },
+    {
+      "id": "with-preview-button",
+      "label": "With Preview Button",
+      "file": "with_preview_button.html"
+    },
+    {
+      "id": "with-title-and-pill-actions",
+      "label": "With Title And Pill Actions",
+      "file": "with_title_and_pill_actions.html"
+    },
+    {
+      "id": "with-underline-and-actions",
+      "label": "With Underline And Actions",
+      "file": "with_underline_and_actions.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/forms/toggles/meta.json
+++ b/src/components/application-ui/forms/toggles/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Forms – Toggles",
+  "slug": "forms/toggles",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "short-toggle",
+      "label": "Short Toggle",
+      "file": "short_toggle.html"
+    },
+    {
+      "id": "simple-toggle",
+      "label": "Simple Toggle",
+      "file": "simple_toggle.html"
+    },
+    {
+      "id": "toggle-with-icon",
+      "label": "Toggle With Icon",
+      "file": "toggle_with_icon.html"
+    },
+    {
+      "id": "with-left-label-and-description",
+      "label": "With Left Label And Description",
+      "file": "with_left_label_and_description.html"
+    },
+    {
+      "id": "with-right-label",
+      "label": "With Right Label",
+      "file": "with_right_label.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/headings/card-headings/meta.json
+++ b/src/components/application-ui/headings/card-headings/meta.json
@@ -1,0 +1,39 @@
+{
+  "title": "Headings – Card Headings",
+  "slug": "headings/card-headings",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-action",
+      "label": "With Action",
+      "file": "with_action.html"
+    },
+    {
+      "id": "with-avatar-meta-and-dropdown",
+      "label": "With Avatar Meta And Dropdown",
+      "file": "with_avatar__meta__and_dropdown.html"
+    },
+    {
+      "id": "with-avatar-and-actions",
+      "label": "With Avatar And Actions",
+      "file": "with_avatar_and_actions.html"
+    },
+    {
+      "id": "with-description-and-action",
+      "label": "With Description And Action",
+      "file": "with_description_and_action.html"
+    },
+    {
+      "id": "with-description",
+      "label": "With Description",
+      "file": "with_description.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/headings/page-headings/meta.json
+++ b/src/components/application-ui/headings/page-headings/meta.json
@@ -1,0 +1,74 @@
+{
+  "title": "Headings – Page Headings",
+  "slug": "headings/page-headings",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "card-with-avatar-and-stats",
+      "label": "Card With Avatar And Stats",
+      "file": "card_with_avatar_and_stats.html"
+    },
+    {
+      "id": "with-actions-and-breadcrumbs-on-dark",
+      "label": "With Actions And Breadcrumbs On Dark",
+      "file": "with_actions_and_breadcrumbs_on_dark.html"
+    },
+    {
+      "id": "with-actions-and-breadcrumbs",
+      "label": "With Actions And Breadcrumbs",
+      "file": "with_actions_and_breadcrumbs.html"
+    },
+    {
+      "id": "with-actions-on-dark",
+      "label": "With Actions On Dark",
+      "file": "with_actions_on_dark.html"
+    },
+    {
+      "id": "with-actions",
+      "label": "With Actions",
+      "file": "with_actions.html"
+    },
+    {
+      "id": "with-avatar-and-actions",
+      "label": "With Avatar And Actions",
+      "file": "with_avatar_and_actions.html"
+    },
+    {
+      "id": "with-banner-image",
+      "label": "With Banner Image",
+      "file": "with_banner_image.html"
+    },
+    {
+      "id": "with-filters-and-action",
+      "label": "With Filters And Action",
+      "file": "with_filters_and_action.html"
+    },
+    {
+      "id": "with-logo-meta-and-actions",
+      "label": "With Logo Meta And Actions",
+      "file": "with_logo__meta_and_actions.html"
+    },
+    {
+      "id": "with-meta-actions-and-breadcrumbs-on-dark",
+      "label": "With Meta Actions And Breadcrumbs On Dark",
+      "file": "with_meta__actions__and_breadcrumbs_on_dark.html"
+    },
+    {
+      "id": "with-meta-actions-and-breadcrumbs",
+      "label": "With Meta Actions And Breadcrumbs",
+      "file": "with_meta__actions__and_breadcrumbs.html"
+    },
+    {
+      "id": "with-meta-and-actions-on-dark",
+      "label": "With Meta And Actions On Dark",
+      "file": "with_meta_and_actions_on_dark.html"
+    },
+    {
+      "id": "with-meta-and-actions",
+      "label": "With Meta And Actions",
+      "file": "with_meta_and_actions.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/headings/section-headings/meta.json
+++ b/src/components/application-ui/headings/section-headings/meta.json
@@ -1,0 +1,59 @@
+{
+  "title": "Headings – Section Headings",
+  "slug": "headings/section-headings",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-action",
+      "label": "With Action",
+      "file": "with_action.html"
+    },
+    {
+      "id": "with-actions-and-tabs",
+      "label": "With Actions And Tabs",
+      "file": "with_actions_and_tabs.html"
+    },
+    {
+      "id": "with-actions",
+      "label": "With Actions",
+      "file": "with_actions.html"
+    },
+    {
+      "id": "with-badge-and-dropdown",
+      "label": "With Badge And Dropdown",
+      "file": "with_badge_and_dropdown.html"
+    },
+    {
+      "id": "with-description",
+      "label": "With Description",
+      "file": "with_description.html"
+    },
+    {
+      "id": "with-inline-tabs",
+      "label": "With Inline Tabs",
+      "file": "with_inline_tabs.html"
+    },
+    {
+      "id": "with-input-group",
+      "label": "With Input Group",
+      "file": "with_input_group.html"
+    },
+    {
+      "id": "with-label",
+      "label": "With Label",
+      "file": "with_label.html"
+    },
+    {
+      "id": "with-tabs",
+      "label": "With Tabs",
+      "file": "with_tabs.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/layout/cards/meta.json
+++ b/src/components/application-ui/layout/cards/meta.json
@@ -1,0 +1,59 @@
+{
+  "title": "Layout – Cards",
+  "slug": "layout/cards",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "basic-card",
+      "label": "Basic Card",
+      "file": "basic_card.html"
+    },
+    {
+      "id": "card-edge-to-edge-on-mobile",
+      "label": "Card Edge To Edge On Mobile",
+      "file": "card__edge_to_edge_on_mobile.html"
+    },
+    {
+      "id": "card-with-footer",
+      "label": "Card With Footer",
+      "file": "card_with_footer.html"
+    },
+    {
+      "id": "card-with-gray-body",
+      "label": "Card With Gray Body",
+      "file": "card_with_gray_body.html"
+    },
+    {
+      "id": "card-with-gray-footer",
+      "label": "Card With Gray Footer",
+      "file": "card_with_gray_footer.html"
+    },
+    {
+      "id": "card-with-header-and-footer",
+      "label": "Card With Header And Footer",
+      "file": "card_with_header_and_footer.html"
+    },
+    {
+      "id": "card-with-header",
+      "label": "Card With Header",
+      "file": "card_with_header.html"
+    },
+    {
+      "id": "well-edge-to-edge-on-mobile",
+      "label": "Well Edge To Edge On Mobile",
+      "file": "well__edge_to_edge_on_mobile.html"
+    },
+    {
+      "id": "well-on-gray",
+      "label": "Well On Gray",
+      "file": "well_on_gray.html"
+    },
+    {
+      "id": "well",
+      "label": "Well",
+      "file": "well.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/layout/containers/meta.json
+++ b/src/components/application-ui/layout/containers/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Layout – Containers",
+  "slug": "layout/containers",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "constrained-to-breakpoint-with-padded-content",
+      "label": "Constrained To Breakpoint With Padded Content",
+      "file": "constrained_to_breakpoint_with_padded_content.html"
+    },
+    {
+      "id": "constrained-with-padded-content",
+      "label": "Constrained With Padded Content",
+      "file": "constrained_with_padded_content.html"
+    },
+    {
+      "id": "full-width-on-mobile-constrained-to-breakpoint-with-padded-content-above-mobile",
+      "label": "Full Width On Mobile Constrained To Breakpoint With Padded Content Above Mobile",
+      "file": "full_width_on_mobile__constrained_to_breakpoint_with_padded_content_above_mobile.html"
+    },
+    {
+      "id": "full-width-on-mobile-constrained-with-padded-content-above",
+      "label": "Full Width On Mobile Constrained With Padded Content Above",
+      "file": "full_width_on_mobile__constrained_with_padded_content_above.html"
+    },
+    {
+      "id": "narrow-constrained-with-padded-content",
+      "label": "Narrow Constrained With Padded Content",
+      "file": "narrow_constrained_with_padded_content.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/layout/dividers/meta.json
+++ b/src/components/application-ui/layout/dividers/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Layout – Dividers",
+  "slug": "layout/dividers",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-button",
+      "label": "With Button",
+      "file": "with_button.html"
+    },
+    {
+      "id": "with-icon",
+      "label": "With Icon",
+      "file": "with_icon.html"
+    },
+    {
+      "id": "with-label-on-left",
+      "label": "With Label On Left",
+      "file": "with_label_on_left.html"
+    },
+    {
+      "id": "with-label",
+      "label": "With Label",
+      "file": "with_label.html"
+    },
+    {
+      "id": "with-title-and-button",
+      "label": "With Title And Button",
+      "file": "with_title_and_button.html"
+    },
+    {
+      "id": "with-title-on-left",
+      "label": "With Title On Left",
+      "file": "with_title_on_left.html"
+    },
+    {
+      "id": "with-title",
+      "label": "With Title",
+      "file": "with_title.html"
+    },
+    {
+      "id": "with-toolbar",
+      "label": "With Toolbar",
+      "file": "with_toolbar.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/layout/list-containers/meta.json
+++ b/src/components/application-ui/layout/list-containers/meta.json
@@ -1,0 +1,44 @@
+{
+  "title": "Layout – List Containers",
+  "slug": "layout/list-containers",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "card-with-dividers-full-width-on-mobile",
+      "label": "Card With Dividers Full Width On Mobile",
+      "file": "card_with_dividers__full_width_on_mobile.html"
+    },
+    {
+      "id": "card-with-dividers",
+      "label": "Card With Dividers",
+      "file": "card_with_dividers.html"
+    },
+    {
+      "id": "flat-card-with-dividers",
+      "label": "Flat Card With Dividers",
+      "file": "flat_card_with_dividers.html"
+    },
+    {
+      "id": "separate-cards-full-width-on-mobile",
+      "label": "Separate Cards Full Width On Mobile",
+      "file": "separate_cards__full_width_on_mobile.html"
+    },
+    {
+      "id": "separate-cards",
+      "label": "Separate Cards",
+      "file": "separate_cards.html"
+    },
+    {
+      "id": "simple-with-dividers-full-width-on-mobile",
+      "label": "Simple With Dividers Full Width On Mobile",
+      "file": "simple_with_dividers__full_width_on_mobile.html"
+    },
+    {
+      "id": "simple-with-dividers",
+      "label": "Simple With Dividers",
+      "file": "simple_with_dividers.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/layout/media-objects/meta.json
+++ b/src/components/application-ui/layout/media-objects/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Layout – Media Objects",
+  "slug": "layout/media-objects",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "aligned-to-bottom",
+      "label": "Aligned To Bottom",
+      "file": "aligned_to_bottom.html"
+    },
+    {
+      "id": "aligned-to-center",
+      "label": "Aligned To Center",
+      "file": "aligned_to_center.html"
+    },
+    {
+      "id": "basic-responsive",
+      "label": "Basic Responsive",
+      "file": "basic_responsive.html"
+    },
+    {
+      "id": "basic",
+      "label": "Basic",
+      "file": "basic.html"
+    },
+    {
+      "id": "media-on-right",
+      "label": "Media On Right",
+      "file": "media_on_right.html"
+    },
+    {
+      "id": "nested",
+      "label": "Nested",
+      "file": "nested.html"
+    },
+    {
+      "id": "stretched-to-fit",
+      "label": "Stretched To Fit",
+      "file": "stretched_to_fit.html"
+    },
+    {
+      "id": "wide-responsive",
+      "label": "Wide Responsive",
+      "file": "wide_responsive.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/lists/feeds/meta.json
+++ b/src/components/application-ui/lists/feeds/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Lists – Feeds",
+  "slug": "lists/feeds",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-with-icons",
+      "label": "Simple With Icons",
+      "file": "simple_with_icons.html"
+    },
+    {
+      "id": "with-comments",
+      "label": "With Comments",
+      "file": "with_comments.html"
+    },
+    {
+      "id": "with-multiple-item-types",
+      "label": "With Multiple Item Types",
+      "file": "with_multiple_item_types.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/lists/grid-lists/meta.json
+++ b/src/components/application-ui/lists/grid-lists/meta.json
@@ -1,0 +1,44 @@
+{
+  "title": "Lists – Grid Lists",
+  "slug": "lists/grid-lists",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "actions-with-shared-borders",
+      "label": "Actions With Shared Borders",
+      "file": "actions_with_shared_borders.html"
+    },
+    {
+      "id": "contact-cards-with-small-portraits",
+      "label": "Contact Cards With Small Portraits",
+      "file": "contact_cards_with_small_portraits.html"
+    },
+    {
+      "id": "contact-cards",
+      "label": "Contact Cards",
+      "file": "contact_cards.html"
+    },
+    {
+      "id": "horizontal-link-cards",
+      "label": "Horizontal Link Cards",
+      "file": "horizontal_link_cards.html"
+    },
+    {
+      "id": "images-with-details",
+      "label": "Images With Details",
+      "file": "images_with_details.html"
+    },
+    {
+      "id": "logos-cards-with-description-list",
+      "label": "Logos Cards With Description List",
+      "file": "logos_cards_with_description_list.html"
+    },
+    {
+      "id": "simple-cards",
+      "label": "Simple Cards",
+      "file": "simple_cards.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/lists/stacked-lists/meta.json
+++ b/src/components/application-ui/lists/stacked-lists/meta.json
@@ -1,0 +1,94 @@
+{
+  "title": "Lists – Stacked Lists",
+  "slug": "lists/stacked-lists",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "full-width-with-constrained-content",
+      "label": "Full Width With Constrained Content",
+      "file": "full_width_with_constrained_content.html"
+    },
+    {
+      "id": "full-width-with-links",
+      "label": "Full Width With Links",
+      "file": "full_width_with_links.html"
+    },
+    {
+      "id": "in-card-with-links",
+      "label": "In Card With Links",
+      "file": "in_card_with_links.html"
+    },
+    {
+      "id": "narrow-with-actions",
+      "label": "Narrow With Actions",
+      "file": "narrow_with_actions.html"
+    },
+    {
+      "id": "narrow-with-badges-on-dark",
+      "label": "Narrow With Badges On Dark",
+      "file": "narrow_with_badges_on_dark.html"
+    },
+    {
+      "id": "narrow-with-small-avatars-on-dark",
+      "label": "Narrow With Small Avatars On Dark",
+      "file": "narrow_with_small_avatars_on_dark.html"
+    },
+    {
+      "id": "narrow-with-small-avatars",
+      "label": "Narrow With Small Avatars",
+      "file": "narrow_with_small_avatars.html"
+    },
+    {
+      "id": "narrow-with-sticky-headings",
+      "label": "Narrow With Sticky Headings",
+      "file": "narrow_with_sticky_headings.html"
+    },
+    {
+      "id": "narrow-with-truncated-content",
+      "label": "Narrow With Truncated Content",
+      "file": "narrow_with_truncated_content.html"
+    },
+    {
+      "id": "narrow",
+      "label": "Narrow",
+      "file": "narrow.html"
+    },
+    {
+      "id": "simple-on-dark",
+      "label": "Simple On Dark",
+      "file": "simple_on_dark.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "two-columns-with-links",
+      "label": "Two Columns With Links",
+      "file": "two_columns_with_links.html"
+    },
+    {
+      "id": "with-badges-button-and-actions-menu",
+      "label": "With Badges Button And Actions Menu",
+      "file": "with_badges__button__and_actions_menu.html"
+    },
+    {
+      "id": "with-inline-links-and-actions-menu",
+      "label": "With Inline Links And Actions Menu",
+      "file": "with_inline_links_and_actions_menu.html"
+    },
+    {
+      "id": "with-inline-links-and-avatar-group",
+      "label": "With Inline Links And Avatar Group",
+      "file": "with_inline_links_and_avatar_group.html"
+    },
+    {
+      "id": "with-links",
+      "label": "With Links",
+      "file": "with_links.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/lists/tables/meta.json
+++ b/src/components/application-ui/lists/tables/meta.json
@@ -1,0 +1,109 @@
+{
+  "title": "Lists – Tables",
+  "slug": "lists/tables",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "full-width-with-avatars-on-dark",
+      "label": "Full Width With Avatars On Dark",
+      "file": "full_width_with_avatars_on_dark.html"
+    },
+    {
+      "id": "full-width-with-constrained-content",
+      "label": "Full Width With Constrained Content",
+      "file": "full_width_with_constrained_content.html"
+    },
+    {
+      "id": "full-width",
+      "label": "Full Width",
+      "file": "full_width.html"
+    },
+    {
+      "id": "simple-in-card",
+      "label": "Simple In Card",
+      "file": "simple_in_card.html"
+    },
+    {
+      "id": "simple-on-dark",
+      "label": "Simple On Dark",
+      "file": "simple_on_dark.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-avatars-and-multi-line-content",
+      "label": "With Avatars And Multi Line Content",
+      "file": "with_avatars_and_multi_line_content.html"
+    },
+    {
+      "id": "with-border",
+      "label": "With Border",
+      "file": "with_border.html"
+    },
+    {
+      "id": "with-checkboxes",
+      "label": "With Checkboxes",
+      "file": "with_checkboxes.html"
+    },
+    {
+      "id": "with-condensed-content",
+      "label": "With Condensed Content",
+      "file": "with_condensed_content.html"
+    },
+    {
+      "id": "with-grouped-rows",
+      "label": "With Grouped Rows",
+      "file": "with_grouped_rows.html"
+    },
+    {
+      "id": "with-hidden-columns-on-mobile",
+      "label": "With Hidden Columns On Mobile",
+      "file": "with_hidden_columns_on_mobile.html"
+    },
+    {
+      "id": "with-hidden-headings",
+      "label": "With Hidden Headings",
+      "file": "with_hidden_headings.html"
+    },
+    {
+      "id": "with-sortable-headings",
+      "label": "With Sortable Headings",
+      "file": "with_sortable_headings.html"
+    },
+    {
+      "id": "with-stacked-columns-on-mobile",
+      "label": "With Stacked Columns On Mobile",
+      "file": "with_stacked_columns_on_mobile.html"
+    },
+    {
+      "id": "with-sticky-header",
+      "label": "With Sticky Header",
+      "file": "with_sticky_header.html"
+    },
+    {
+      "id": "with-striped-rows",
+      "label": "With Striped Rows",
+      "file": "with_striped_rows.html"
+    },
+    {
+      "id": "with-summary-rows",
+      "label": "With Summary Rows",
+      "file": "with_summary_rows.html"
+    },
+    {
+      "id": "with-uppercase-headings",
+      "label": "With Uppercase Headings",
+      "file": "with_uppercase_headings.html"
+    },
+    {
+      "id": "with-vertical-lines",
+      "label": "With Vertical Lines",
+      "file": "with_vertical_lines.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/navigation/breadcrumbs/meta.json
+++ b/src/components/application-ui/navigation/breadcrumbs/meta.json
@@ -1,0 +1,29 @@
+{
+  "title": "Navigation – Breadcrumbs",
+  "slug": "navigation/breadcrumbs",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "contained",
+      "label": "Contained",
+      "file": "contained.html"
+    },
+    {
+      "id": "full-width-bar",
+      "label": "Full Width Bar",
+      "file": "full_width_bar.html"
+    },
+    {
+      "id": "simple-with-chevrons",
+      "label": "Simple With Chevrons",
+      "file": "simple_with_chevrons.html"
+    },
+    {
+      "id": "simple-with-slashes",
+      "label": "Simple With Slashes",
+      "file": "simple_with_slashes.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/navigation/command-palettes/meta.json
+++ b/src/components/application-ui/navigation/command-palettes/meta.json
@@ -1,0 +1,54 @@
+{
+  "title": "Navigation – Command Palettes",
+  "slug": "navigation/command-palettes",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "dark-with-icons",
+      "label": "Dark With Icons",
+      "file": "dark_with_icons.html"
+    },
+    {
+      "id": "semi-transparent-with-icons",
+      "label": "Semi Transparent With Icons",
+      "file": "semi_transparent_with_icons.html"
+    },
+    {
+      "id": "simple-with-padding",
+      "label": "Simple With Padding",
+      "file": "simple_with_padding.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-footer",
+      "label": "With Footer",
+      "file": "with_footer.html"
+    },
+    {
+      "id": "with-groups",
+      "label": "With Groups",
+      "file": "with_groups.html"
+    },
+    {
+      "id": "with-icons",
+      "label": "With Icons",
+      "file": "with_icons.html"
+    },
+    {
+      "id": "with-images-and-descriptions",
+      "label": "With Images And Descriptions",
+      "file": "with_images_and_descriptions.html"
+    },
+    {
+      "id": "with-preview",
+      "label": "With Preview",
+      "file": "with_preview.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/navigation/navbars/meta.json
+++ b/src/components/application-ui/navigation/navbars/meta.json
@@ -1,0 +1,64 @@
+{
+  "title": "Navigation – Navbars",
+  "slug": "navigation/navbars",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "dark-with-quick-action",
+      "label": "Dark With Quick Action",
+      "file": "dark_with_quick_action.html"
+    },
+    {
+      "id": "dark-with-search",
+      "label": "Dark With Search",
+      "file": "dark_with_search.html"
+    },
+    {
+      "id": "simple-dark-with-menu-button-on-left",
+      "label": "Simple Dark With Menu Button On Left",
+      "file": "simple_dark_with_menu_button_on_left.html"
+    },
+    {
+      "id": "simple-dark",
+      "label": "Simple Dark",
+      "file": "simple_dark.html"
+    },
+    {
+      "id": "simple-with-menu-button-on-left",
+      "label": "Simple With Menu Button On Left",
+      "file": "simple_with_menu_button_on_left.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-centered-search-and-secondary-links-dark",
+      "label": "With Centered Search And Secondary Links Dark",
+      "file": "with_centered_search_and_secondary_links_dark.html"
+    },
+    {
+      "id": "with-centered-search-and-secondary-links",
+      "label": "With Centered Search And Secondary Links",
+      "file": "with_centered_search_and_secondary_links.html"
+    },
+    {
+      "id": "with-quick-action",
+      "label": "With Quick Action",
+      "file": "with_quick_action.html"
+    },
+    {
+      "id": "with-search-in-column-layout",
+      "label": "With Search In Column Layout",
+      "file": "with_search_in_column_layout.html"
+    },
+    {
+      "id": "with-search",
+      "label": "With Search",
+      "file": "with_search.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/navigation/pagination/meta.json
+++ b/src/components/application-ui/navigation/pagination/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Navigation – Pagination",
+  "slug": "navigation/pagination",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "card-footer-with-page-buttons",
+      "label": "Card Footer With Page Buttons",
+      "file": "card_footer_with_page_buttons.html"
+    },
+    {
+      "id": "centered-page-numbers",
+      "label": "Centered Page Numbers",
+      "file": "centered_page_numbers.html"
+    },
+    {
+      "id": "simple-card-footer",
+      "label": "Simple Card Footer",
+      "file": "simple_card_footer.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/navigation/progress-bars/meta.json
+++ b/src/components/application-ui/navigation/progress-bars/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Navigation – Progress Bars",
+  "slug": "navigation/progress-bars",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "bullets-and-text",
+      "label": "Bullets And Text",
+      "file": "bullets_and_text.html"
+    },
+    {
+      "id": "bullets",
+      "label": "Bullets",
+      "file": "bullets.html"
+    },
+    {
+      "id": "circles-with-text",
+      "label": "Circles With Text",
+      "file": "circles_with_text.html"
+    },
+    {
+      "id": "circles",
+      "label": "Circles",
+      "file": "circles.html"
+    },
+    {
+      "id": "panels-with-border",
+      "label": "Panels With Border",
+      "file": "panels_with_border.html"
+    },
+    {
+      "id": "panels",
+      "label": "Panels",
+      "file": "panels.html"
+    },
+    {
+      "id": "progress-bar",
+      "label": "Progress Bar",
+      "file": "progress_bar.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/navigation/sidebar-navigation/meta.json
+++ b/src/components/application-ui/navigation/sidebar-navigation/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Navigation – Sidebar Navigation",
+  "slug": "navigation/sidebar-navigation",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "brand",
+      "label": "Brand",
+      "file": "brand.html"
+    },
+    {
+      "id": "dark",
+      "label": "Dark",
+      "file": "dark.html"
+    },
+    {
+      "id": "light",
+      "label": "Light",
+      "file": "light.html"
+    },
+    {
+      "id": "with-expandable-sections",
+      "label": "With Expandable Sections",
+      "file": "with_expandable_sections.html"
+    },
+    {
+      "id": "with-secondary-navigation",
+      "label": "With Secondary Navigation",
+      "file": "with_secondary_navigation.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/navigation/tabs/meta.json
+++ b/src/components/application-ui/navigation/tabs/meta.json
@@ -1,0 +1,54 @@
+{
+  "title": "Navigation – Tabs",
+  "slug": "navigation/tabs",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "bar-with-underline",
+      "label": "Bar With Underline",
+      "file": "bar_with_underline.html"
+    },
+    {
+      "id": "full-width-tabs-with-underline",
+      "label": "Full Width Tabs With Underline",
+      "file": "full_width_tabs_with_underline.html"
+    },
+    {
+      "id": "simple-on-dark",
+      "label": "Simple On Dark",
+      "file": "simple_on_dark.html"
+    },
+    {
+      "id": "tabs-in-pills-on-gray",
+      "label": "Tabs In Pills On Gray",
+      "file": "tabs_in_pills_on_gray.html"
+    },
+    {
+      "id": "tabs-in-pills-with-brand-color",
+      "label": "Tabs In Pills With Brand Color",
+      "file": "tabs_in_pills_with_brand_color.html"
+    },
+    {
+      "id": "tabs-in-pills",
+      "label": "Tabs In Pills",
+      "file": "tabs_in_pills.html"
+    },
+    {
+      "id": "tabs-with-underline-and-badges",
+      "label": "Tabs With Underline And Badges",
+      "file": "tabs_with_underline_and_badges.html"
+    },
+    {
+      "id": "tabs-with-underline-and-icons",
+      "label": "Tabs With Underline And Icons",
+      "file": "tabs_with_underline_and_icons.html"
+    },
+    {
+      "id": "tabs-with-underline",
+      "label": "Tabs With Underline",
+      "file": "tabs_with_underline.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/navigation/vertical-navigation/meta.json
+++ b/src/components/application-ui/navigation/vertical-navigation/meta.json
@@ -1,0 +1,39 @@
+{
+  "title": "Navigation – Vertical Navigation",
+  "slug": "navigation/vertical-navigation",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "on-gray",
+      "label": "On Gray",
+      "file": "on_gray.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-badges",
+      "label": "With Badges",
+      "file": "with_badges.html"
+    },
+    {
+      "id": "with-icons-and-badges",
+      "label": "With Icons And Badges",
+      "file": "with_icons_and_badges.html"
+    },
+    {
+      "id": "with-icons",
+      "label": "With Icons",
+      "file": "with_icons.html"
+    },
+    {
+      "id": "with-secondary-navigation",
+      "label": "With Secondary Navigation",
+      "file": "with_secondary_navigation.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/overlays/drawers/meta.json
+++ b/src/components/application-ui/overlays/drawers/meta.json
@@ -1,0 +1,69 @@
+{
+  "title": "Overlays – Drawers",
+  "slug": "overlays/drawers",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "contact-list-example",
+      "label": "Contact List Example",
+      "file": "contact_list_example.html"
+    },
+    {
+      "id": "create-project-form-example",
+      "label": "Create Project Form Example",
+      "file": "create_project_form_example.html"
+    },
+    {
+      "id": "empty",
+      "label": "Empty",
+      "file": "empty.html"
+    },
+    {
+      "id": "file-details-example",
+      "label": "File Details Example",
+      "file": "file_details_example.html"
+    },
+    {
+      "id": "user-profile-example",
+      "label": "User Profile Example",
+      "file": "user_profile_example.html"
+    },
+    {
+      "id": "wide-create-project-form-example",
+      "label": "Wide Create Project Form Example",
+      "file": "wide_create_project_form_example.html"
+    },
+    {
+      "id": "wide-empty",
+      "label": "Wide Empty",
+      "file": "wide_empty.html"
+    },
+    {
+      "id": "wide-horizontal-user-profile-example",
+      "label": "Wide Horizontal User Profile Example",
+      "file": "wide_horizontal_user_profile_example.html"
+    },
+    {
+      "id": "with-background-overlay",
+      "label": "With Background Overlay",
+      "file": "with_background_overlay.html"
+    },
+    {
+      "id": "with-branded-header",
+      "label": "With Branded Header",
+      "file": "with_branded_header.html"
+    },
+    {
+      "id": "with-close-button-on-outside",
+      "label": "With Close Button On Outside",
+      "file": "with_close_button_on_outside.html"
+    },
+    {
+      "id": "with-sticky-footer",
+      "label": "With Sticky Footer",
+      "file": "with_sticky_footer.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/overlays/modal-dialogs/meta.json
+++ b/src/components/application-ui/overlays/modal-dialogs/meta.json
@@ -1,0 +1,39 @@
+{
+  "title": "Overlays – Modal Dialogs",
+  "slug": "overlays/modal-dialogs",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "centered-with-single-action",
+      "label": "Centered With Single Action",
+      "file": "centered_with_single_action.html"
+    },
+    {
+      "id": "centered-with-wide-buttons",
+      "label": "Centered With Wide Buttons",
+      "file": "centered_with_wide_buttons.html"
+    },
+    {
+      "id": "simple-alert-with-left-aligned-buttons",
+      "label": "Simple Alert With Left Aligned Buttons",
+      "file": "simple_alert_with_left_aligned_buttons.html"
+    },
+    {
+      "id": "simple-alert",
+      "label": "Simple Alert",
+      "file": "simple_alert.html"
+    },
+    {
+      "id": "simple-with-dismiss-button",
+      "label": "Simple With Dismiss Button",
+      "file": "simple_with_dismiss_button.html"
+    },
+    {
+      "id": "simple-with-gray-footer",
+      "label": "Simple With Gray Footer",
+      "file": "simple_with_gray_footer.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/overlays/notifications/meta.json
+++ b/src/components/application-ui/overlays/notifications/meta.json
@@ -1,0 +1,39 @@
+{
+  "title": "Overlays – Notifications",
+  "slug": "overlays/notifications",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "condensed",
+      "label": "Condensed",
+      "file": "condensed.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-actions-below",
+      "label": "With Actions Below",
+      "file": "with_actions_below.html"
+    },
+    {
+      "id": "with-avatar",
+      "label": "With Avatar",
+      "file": "with_avatar.html"
+    },
+    {
+      "id": "with-buttons-below",
+      "label": "With Buttons Below",
+      "file": "with_buttons_below.html"
+    },
+    {
+      "id": "with-split-buttons",
+      "label": "With Split Buttons",
+      "file": "with_split_buttons.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/page-examples/detail-screens/meta.json
+++ b/src/components/application-ui/page-examples/detail-screens/meta.json
@@ -1,0 +1,19 @@
+{
+  "title": "Page Examples – Detail Screens",
+  "slug": "page-examples/detail-screens",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "sidebar-on-dark",
+      "label": "Sidebar On Dark",
+      "file": "sidebar_on_dark.html"
+    },
+    {
+      "id": "stacked",
+      "label": "Stacked",
+      "file": "stacked.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/page-examples/home-screens/meta.json
+++ b/src/components/application-ui/page-examples/home-screens/meta.json
@@ -1,0 +1,19 @@
+{
+  "title": "Page Examples – Home Screens",
+  "slug": "page-examples/home-screens",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "sidebar-on-dark",
+      "label": "Sidebar On Dark",
+      "file": "sidebar_on_dark.html"
+    },
+    {
+      "id": "stacked",
+      "label": "Stacked",
+      "file": "stacked.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/application-ui/page-examples/settings-screens/meta.json
+++ b/src/components/application-ui/page-examples/settings-screens/meta.json
@@ -1,0 +1,19 @@
+{
+  "title": "Page Examples – Settings Screens",
+  "slug": "page-examples/settings-screens",
+  "category": "application-ui",
+  "tags": [],
+  "variants": [
+    {
+      "id": "sidebar-on-dark",
+      "label": "Sidebar On Dark",
+      "file": "sidebar_on_dark.html"
+    },
+    {
+      "id": "stacked",
+      "label": "Stacked",
+      "file": "stacked.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/category-filters/meta.json
+++ b/src/components/ecommerce/components/category-filters/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Components – Category Filters",
+  "slug": "components/category-filters",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "sidebar-filters",
+      "label": "Sidebar Filters",
+      "file": "sidebar_filters.html"
+    },
+    {
+      "id": "with-centered-text-and-dropdown-product-filters",
+      "label": "With Centered Text And Dropdown Product Filters",
+      "file": "with_centered_text_and_dropdown_product_filters.html"
+    },
+    {
+      "id": "with-dropdown-product-filters",
+      "label": "With Dropdown Product Filters",
+      "file": "with_dropdown_product_filters.html"
+    },
+    {
+      "id": "with-expandable-product-filter-panel",
+      "label": "With Expandable Product Filter Panel",
+      "file": "with_expandable_product_filter_panel.html"
+    },
+    {
+      "id": "with-inline-actions-and-expandable-sidebar-filters",
+      "label": "With Inline Actions And Expandable Sidebar Filters",
+      "file": "with_inline_actions_and_expandable_sidebar_filters.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/category-previews/meta.json
+++ b/src/components/ecommerce/components/category-previews/meta.json
@@ -1,0 +1,39 @@
+{
+  "title": "Components – Category Previews",
+  "slug": "components/category-previews",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "three-column-with-description",
+      "label": "Three Column With Description",
+      "file": "three_column_with_description.html"
+    },
+    {
+      "id": "three-column",
+      "label": "Three Column",
+      "file": "three_column.html"
+    },
+    {
+      "id": "with-background-image-and-detail-overlay",
+      "label": "With Background Image And Detail Overlay",
+      "file": "with_background_image_and_detail_overlay.html"
+    },
+    {
+      "id": "with-image-backgrounds",
+      "label": "With Image Backgrounds",
+      "file": "with_image_backgrounds.html"
+    },
+    {
+      "id": "with-scrolling-cards",
+      "label": "With Scrolling Cards",
+      "file": "with_scrolling_cards.html"
+    },
+    {
+      "id": "with-split-images",
+      "label": "With Split Images",
+      "file": "with_split_images.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/checkout-forms/meta.json
+++ b/src/components/ecommerce/components/checkout-forms/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Components – Checkout Forms",
+  "slug": "components/checkout-forms",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "multi-step",
+      "label": "Multi Step",
+      "file": "multi_step.html"
+    },
+    {
+      "id": "single-step-with-order-summary",
+      "label": "Single Step With Order Summary",
+      "file": "single_step_with_order_summary.html"
+    },
+    {
+      "id": "split-with-order-summary",
+      "label": "Split With Order Summary",
+      "file": "split_with_order_summary.html"
+    },
+    {
+      "id": "with-mobile-order-summary-overlay",
+      "label": "With Mobile Order Summary Overlay",
+      "file": "with_mobile_order_summary_overlay.html"
+    },
+    {
+      "id": "with-order-summary-sidebar",
+      "label": "With Order Summary Sidebar",
+      "file": "with_order_summary_sidebar.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/incentives/meta.json
+++ b/src/components/ecommerce/components/incentives/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Components – Incentives",
+  "slug": "components/incentives",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "2x2-grid-with-illustrations",
+      "label": "2x2 Grid With Illustrations",
+      "file": "2x2_grid_with_illustrations.html"
+    },
+    {
+      "id": "3-column-with-icons-and-supporting-text",
+      "label": "3 Column With Icons And Supporting Text",
+      "file": "3_column_with_icons_and_supporting_text.html"
+    },
+    {
+      "id": "3-column-with-icons",
+      "label": "3 Column With Icons",
+      "file": "3_column_with_icons.html"
+    },
+    {
+      "id": "3-column-with-illustrations-and-centered-text",
+      "label": "3 Column With Illustrations And Centered Text",
+      "file": "3_column_with_illustrations_and_centered_text.html"
+    },
+    {
+      "id": "3-column-with-illustrations-and-header",
+      "label": "3 Column With Illustrations And Header",
+      "file": "3_column_with_illustrations_and_header.html"
+    },
+    {
+      "id": "3-column-with-illustrations-and-heading",
+      "label": "3 Column With Illustrations And Heading",
+      "file": "3_column_with_illustrations_and_heading.html"
+    },
+    {
+      "id": "3-column-with-illustrations-and-split-header",
+      "label": "3 Column With Illustrations And Split Header",
+      "file": "3_column_with_illustrations_and_split_header.html"
+    },
+    {
+      "id": "4-column-with-illustrations",
+      "label": "4 Column With Illustrations",
+      "file": "4_column_with_illustrations.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/order-history/meta.json
+++ b/src/components/ecommerce/components/order-history/meta.json
@@ -1,0 +1,29 @@
+{
+  "title": "Components – Order History",
+  "slug": "components/order-history",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "invoice-list-with-quick-actions",
+      "label": "Invoice List With Quick Actions",
+      "file": "invoice_list_with_quick_actions.html"
+    },
+    {
+      "id": "invoice-list",
+      "label": "Invoice List",
+      "file": "invoice_list.html"
+    },
+    {
+      "id": "invoice-panels",
+      "label": "Invoice Panels",
+      "file": "invoice_panels.html"
+    },
+    {
+      "id": "invoice-table",
+      "label": "Invoice Table",
+      "file": "invoice_table.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/order-summaries/meta.json
+++ b/src/components/ecommerce/components/order-summaries/meta.json
@@ -1,0 +1,29 @@
+{
+  "title": "Components – Order Summaries",
+  "slug": "components/order-summaries",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-with-full-order-details",
+      "label": "Simple With Full Order Details",
+      "file": "simple_with_full_order_details.html"
+    },
+    {
+      "id": "with-large-images-and-progress-bars",
+      "label": "With Large Images And Progress Bars",
+      "file": "with_large_images_and_progress_bars.html"
+    },
+    {
+      "id": "with-progress-bars",
+      "label": "With Progress Bars",
+      "file": "with_progress_bars.html"
+    },
+    {
+      "id": "with-split-image",
+      "label": "With Split Image",
+      "file": "with_split_image.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/product-features/meta.json
+++ b/src/components/ecommerce/components/product-features/meta.json
@@ -1,0 +1,54 @@
+{
+  "title": "Components – Product Features",
+  "slug": "components/product-features",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-alternating-sections",
+      "label": "With Alternating Sections",
+      "file": "with_alternating_sections.html"
+    },
+    {
+      "id": "with-fading-image",
+      "label": "With Fading Image",
+      "file": "with_fading_image.html"
+    },
+    {
+      "id": "with-header-images-and-descriptions",
+      "label": "With Header Images And Descriptions",
+      "file": "with_header__images__and_descriptions.html"
+    },
+    {
+      "id": "with-image-grid",
+      "label": "With Image Grid",
+      "file": "with_image_grid.html"
+    },
+    {
+      "id": "with-split-image",
+      "label": "With Split Image",
+      "file": "with_split_image.html"
+    },
+    {
+      "id": "with-square-images",
+      "label": "With Square Images",
+      "file": "with_square_images.html"
+    },
+    {
+      "id": "with-tabs",
+      "label": "With Tabs",
+      "file": "with_tabs.html"
+    },
+    {
+      "id": "with-tiered-images",
+      "label": "With Tiered Images",
+      "file": "with_tiered_images.html"
+    },
+    {
+      "id": "with-wide-images",
+      "label": "With Wide Images",
+      "file": "with_wide_images.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/product-lists/meta.json
+++ b/src/components/ecommerce/components/product-lists/meta.json
@@ -1,0 +1,64 @@
+{
+  "title": "Components – Product Lists",
+  "slug": "components/product-lists",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "card-with-full-details",
+      "label": "Card With Full Details",
+      "file": "card_with_full_details.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-border-grid",
+      "label": "With Border Grid",
+      "file": "with_border_grid.html"
+    },
+    {
+      "id": "with-color-swatches-and-horizontal-scrolling",
+      "label": "With Color Swatches And Horizontal Scrolling",
+      "file": "with_color_swatches_and_horizontal_scrolling.html"
+    },
+    {
+      "id": "with-cta-link",
+      "label": "With CTA Link",
+      "file": "with_cta_link.html"
+    },
+    {
+      "id": "with-image-overlay-and-add-button",
+      "label": "With Image Overlay And Add Button",
+      "file": "with_image_overlay_and_add_button.html"
+    },
+    {
+      "id": "with-inline-price-and-cta-link",
+      "label": "With Inline Price And CTA Link",
+      "file": "with_inline_price_and_cta_link.html"
+    },
+    {
+      "id": "with-inline-price",
+      "label": "With Inline Price",
+      "file": "with_inline_price.html"
+    },
+    {
+      "id": "with-supporting-text",
+      "label": "With Supporting Text",
+      "file": "with_supporting_text.html"
+    },
+    {
+      "id": "with-tall-images-and-cta-link",
+      "label": "With Tall Images And CTA Link",
+      "file": "with_tall_images_and_cta_link.html"
+    },
+    {
+      "id": "with-tall-images",
+      "label": "With Tall Images",
+      "file": "with_tall_images.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/product-overviews/meta.json
+++ b/src/components/ecommerce/components/product-overviews/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Components – Product Overviews",
+  "slug": "components/product-overviews",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "split-with-image",
+      "label": "Split With Image",
+      "file": "split_with_image.html"
+    },
+    {
+      "id": "with-image-gallery-and-expandable-details",
+      "label": "With Image Gallery And Expandable Details",
+      "file": "with_image_gallery_and_expandable_details.html"
+    },
+    {
+      "id": "with-image-grid",
+      "label": "With Image Grid",
+      "file": "with_image_grid.html"
+    },
+    {
+      "id": "with-tabs",
+      "label": "With Tabs",
+      "file": "with_tabs.html"
+    },
+    {
+      "id": "with-tiered-images",
+      "label": "With Tiered Images",
+      "file": "with_tiered_images.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/product-quickviews/meta.json
+++ b/src/components/ecommerce/components/product-quickviews/meta.json
@@ -1,0 +1,29 @@
+{
+  "title": "Components – Product Quickviews",
+  "slug": "components/product-quickviews",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-color-and-size-selector",
+      "label": "With Color And Size Selector",
+      "file": "with_color_and_size_selector.html"
+    },
+    {
+      "id": "with-color-selector-size-selector-and-details-link",
+      "label": "With Color Selector Size Selector And Details Link",
+      "file": "with_color_selector__size_selector__and_details_link.html"
+    },
+    {
+      "id": "with-color-selector-and-description",
+      "label": "With Color Selector And Description",
+      "file": "with_color_selector_and_description.html"
+    },
+    {
+      "id": "with-large-size-selector",
+      "label": "With Large Size Selector",
+      "file": "with_large_size_selector.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/promo-sections/meta.json
+++ b/src/components/ecommerce/components/promo-sections/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Components – Promo Sections",
+  "slug": "components/promo-sections",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "full-width-with-background-image-and-large-content",
+      "label": "Full Width With Background Image And Large Content",
+      "file": "full_width_with_background_image_and_large_content.html"
+    },
+    {
+      "id": "full-width-with-background-image",
+      "label": "Full Width With Background Image",
+      "file": "full_width_with_background_image.html"
+    },
+    {
+      "id": "full-width-with-overlapping-image-tiles",
+      "label": "Full Width With Overlapping Image Tiles",
+      "file": "full_width_with_overlapping_image_tiles.html"
+    },
+    {
+      "id": "with-background-image",
+      "label": "With Background Image",
+      "file": "with_background_image.html"
+    },
+    {
+      "id": "with-fading-background-image-and-testimonials",
+      "label": "With Fading Background Image And Testimonials",
+      "file": "with_fading_background_image_and_testimonials.html"
+    },
+    {
+      "id": "with-image-tiles",
+      "label": "With Image Tiles",
+      "file": "with_image_tiles.html"
+    },
+    {
+      "id": "with-offers-and-split-image",
+      "label": "With Offers And Split Image",
+      "file": "with_offers_and_split_image.html"
+    },
+    {
+      "id": "with-overlapping-image-tiles",
+      "label": "With Overlapping Image Tiles",
+      "file": "with_overlapping_image_tiles.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/reviews/meta.json
+++ b/src/components/ecommerce/components/reviews/meta.json
@@ -1,0 +1,29 @@
+{
+  "title": "Components – Reviews",
+  "slug": "components/reviews",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "avatars-with-separate-description",
+      "label": "Avatars With Separate Description",
+      "file": "avatars_with_separate_description.html"
+    },
+    {
+      "id": "multi-column",
+      "label": "Multi Column",
+      "file": "multi_column.html"
+    },
+    {
+      "id": "simple-with-avatars",
+      "label": "Simple With Avatars",
+      "file": "simple_with_avatars.html"
+    },
+    {
+      "id": "with-summary-chart",
+      "label": "With Summary Chart",
+      "file": "with_summary_chart.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/shopping-carts/meta.json
+++ b/src/components/ecommerce/components/shopping-carts/meta.json
@@ -1,0 +1,39 @@
+{
+  "title": "Components – Shopping Carts",
+  "slug": "components/shopping-carts",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "modal",
+      "label": "Modal",
+      "file": "modal.html"
+    },
+    {
+      "id": "popover",
+      "label": "Popover",
+      "file": "popover.html"
+    },
+    {
+      "id": "single-column",
+      "label": "Single Column",
+      "file": "single_column.html"
+    },
+    {
+      "id": "slide-over",
+      "label": "Slide Over",
+      "file": "slide_over.html"
+    },
+    {
+      "id": "two-column-with-quantity-dropdown",
+      "label": "Two Column With Quantity Dropdown",
+      "file": "two_column_with_quantity_dropdown.html"
+    },
+    {
+      "id": "with-extended-summary",
+      "label": "With Extended Summary",
+      "file": "with_extended_summary.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/components/store-navigation/meta.json
+++ b/src/components/ecommerce/components/store-navigation/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Components – Store Navigation",
+  "slug": "components/store-navigation",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-centered-logo-and-featured-categories",
+      "label": "With Centered Logo And Featured Categories",
+      "file": "with_centered_logo_and_featured_categories.html"
+    },
+    {
+      "id": "with-double-column-and-persistent-mobile-nav",
+      "label": "With Double Column And Persistent Mobile Nav",
+      "file": "with_double_column_and_persistent_mobile_nav.html"
+    },
+    {
+      "id": "with-featured-categories",
+      "label": "With Featured Categories",
+      "file": "with_featured_categories.html"
+    },
+    {
+      "id": "with-image-grid",
+      "label": "With Image Grid",
+      "file": "with_image_grid.html"
+    },
+    {
+      "id": "with-simple-menu-and-promo",
+      "label": "With Simple Menu And Promo",
+      "file": "with_simple_menu_and_promo.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/page-examples/category-pages/meta.json
+++ b/src/components/ecommerce/page-examples/category-pages/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Page Examples – Category Pages",
+  "slug": "page-examples/category-pages",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-image-header-and-detail-product-grid",
+      "label": "With Image Header And Detail Product Grid",
+      "file": "with_image_header_and_detail_product_grid.html"
+    },
+    {
+      "id": "with-large-images-and-filters-sidebar",
+      "label": "With Large Images And Filters Sidebar",
+      "file": "with_large_images_and_filters_sidebar.html"
+    },
+    {
+      "id": "with-product-grid-and-pagination",
+      "label": "With Product Grid And Pagination",
+      "file": "with_product_grid_and_pagination.html"
+    },
+    {
+      "id": "with-text-header-and-image-product-grid",
+      "label": "With Text Header And Image Product Grid",
+      "file": "with_text_header_and_image_product_grid.html"
+    },
+    {
+      "id": "with-text-header-and-simple-product-grid",
+      "label": "With Text Header And Simple Product Grid",
+      "file": "with_text_header_and_simple_product_grid.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/page-examples/checkout-pages/meta.json
+++ b/src/components/ecommerce/page-examples/checkout-pages/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Page Examples – Checkout Pages",
+  "slug": "page-examples/checkout-pages",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "multi-step",
+      "label": "Multi Step",
+      "file": "multi_step.html"
+    },
+    {
+      "id": "single-step-with-order-summary",
+      "label": "Single Step With Order Summary",
+      "file": "single_step_with_order_summary.html"
+    },
+    {
+      "id": "split-with-order-summary",
+      "label": "Split With Order Summary",
+      "file": "split_with_order_summary.html"
+    },
+    {
+      "id": "with-mobile-order-summary-overlay",
+      "label": "With Mobile Order Summary Overlay",
+      "file": "with_mobile_order_summary_overlay.html"
+    },
+    {
+      "id": "with-order-summary-sidebar",
+      "label": "With Order Summary Sidebar",
+      "file": "with_order_summary_sidebar.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/page-examples/order-detail-pages/meta.json
+++ b/src/components/ecommerce/page-examples/order-detail-pages/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Page Examples – Order Detail Pages",
+  "slug": "page-examples/order-detail-pages",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-with-full-order-details",
+      "label": "Simple With Full Order Details",
+      "file": "simple_with_full_order_details.html"
+    },
+    {
+      "id": "with-large-images-and-progress-bars",
+      "label": "With Large Images And Progress Bars",
+      "file": "with_large_images_and_progress_bars.html"
+    },
+    {
+      "id": "with-progress-bars",
+      "label": "With Progress Bars",
+      "file": "with_progress_bars.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/page-examples/order-history-pages/meta.json
+++ b/src/components/ecommerce/page-examples/order-history-pages/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Page Examples – Order History Pages",
+  "slug": "page-examples/order-history-pages",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-invoice-list-and-quick-actions",
+      "label": "With Invoice List And Quick Actions",
+      "file": "with_invoice_list_and_quick_actions.html"
+    },
+    {
+      "id": "with-invoice-list",
+      "label": "With Invoice List",
+      "file": "with_invoice_list.html"
+    },
+    {
+      "id": "with-invoice-panels",
+      "label": "With Invoice Panels",
+      "file": "with_invoice_panels.html"
+    },
+    {
+      "id": "with-invoice-tables",
+      "label": "With Invoice Tables",
+      "file": "with_invoice_tables.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/page-examples/product-pages/meta.json
+++ b/src/components/ecommerce/page-examples/product-pages/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Page Examples – Product Pages",
+  "slug": "page-examples/product-pages",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-expandable-product-details",
+      "label": "With Expandable Product Details",
+      "file": "with_expandable_product_details.html"
+    },
+    {
+      "id": "with-featured-details",
+      "label": "With Featured Details",
+      "file": "with_featured_details.html"
+    },
+    {
+      "id": "with-image-grid",
+      "label": "With Image Grid",
+      "file": "with_image_grid.html"
+    },
+    {
+      "id": "with-related-products",
+      "label": "With Related Products",
+      "file": "with_related_products.html"
+    },
+    {
+      "id": "with-tabs-and-related-products",
+      "label": "With Tabs And Related Products",
+      "file": "with_tabs_and_related_products.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/page-examples/shopping-cart-pages/meta.json
+++ b/src/components/ecommerce/page-examples/shopping-cart-pages/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Page Examples – Shopping Cart Pages",
+  "slug": "page-examples/shopping-cart-pages",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-with-policy-grid",
+      "label": "Simple With Policy Grid",
+      "file": "simple_with_policy_grid.html"
+    },
+    {
+      "id": "with-policy-grid-and-extended-summary",
+      "label": "With Policy Grid And Extended Summary",
+      "file": "with_policy_grid_and_extended_summary.html"
+    },
+    {
+      "id": "with-related-products",
+      "label": "With Related Products",
+      "file": "with_related_products.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/ecommerce/page-examples/storefront-pages/meta.json
+++ b/src/components/ecommerce/page-examples/storefront-pages/meta.json
@@ -1,0 +1,29 @@
+{
+  "title": "Page Examples – Storefront Pages",
+  "slug": "page-examples/storefront-pages",
+  "category": "ecommerce",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-dark-nav-and-footer",
+      "label": "With Dark Nav And Footer",
+      "file": "with_dark_nav_and_footer.html"
+    },
+    {
+      "id": "with-image-tiles-and-feature-sections",
+      "label": "With Image Tiles And Feature Sections",
+      "file": "with_image_tiles_and_feature_sections.html"
+    },
+    {
+      "id": "with-offers-and-testimonials",
+      "label": "With Offers And Testimonials",
+      "file": "with_offers_and_testimonials.html"
+    },
+    {
+      "id": "with-overlapping-image-tiles-and-perks",
+      "label": "With Overlapping Image Tiles And Perks",
+      "file": "with_overlapping_image_tiles_and_perks.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/elements/banners/meta.json
+++ b/src/components/marketing/elements/banners/meta.json
@@ -1,0 +1,74 @@
+{
+  "title": "Elements – Banners",
+  "slug": "elements/banners",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "bottom-aligned",
+      "label": "Bottom Aligned",
+      "file": "bottom_aligned.html"
+    },
+    {
+      "id": "floating-at-bottom-centered",
+      "label": "Floating At Bottom Centered",
+      "file": "floating_at_bottom_centered.html"
+    },
+    {
+      "id": "floating-at-bottom",
+      "label": "Floating At Bottom",
+      "file": "floating_at_bottom.html"
+    },
+    {
+      "id": "left-aligned",
+      "label": "Left Aligned",
+      "file": "left_aligned.html"
+    },
+    {
+      "id": "on-brand",
+      "label": "On Brand",
+      "file": "on_brand.html"
+    },
+    {
+      "id": "on-dark",
+      "label": "On Dark",
+      "file": "on_dark.html"
+    },
+    {
+      "id": "privacy-notice-centered",
+      "label": "Privacy Notice Centered",
+      "file": "privacy_notice_centered.html"
+    },
+    {
+      "id": "privacy-notice-full-width",
+      "label": "Privacy Notice Full Width",
+      "file": "privacy_notice_full_width.html"
+    },
+    {
+      "id": "privacy-notice-left-aligned",
+      "label": "Privacy Notice Left Aligned",
+      "file": "privacy_notice_left_aligned.html"
+    },
+    {
+      "id": "privacy-notice-right-aligned",
+      "label": "Privacy Notice Right Aligned",
+      "file": "privacy_notice_right_aligned.html"
+    },
+    {
+      "id": "with-background-glow",
+      "label": "With Background Glow",
+      "file": "with_background_glow.html"
+    },
+    {
+      "id": "with-button",
+      "label": "With Button",
+      "file": "with_button.html"
+    },
+    {
+      "id": "with-link",
+      "label": "With Link",
+      "file": "with_link.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/elements/flyout-menus/meta.json
+++ b/src/components/marketing/elements/flyout-menus/meta.json
@@ -1,0 +1,44 @@
+{
+  "title": "Elements – Flyout Menus",
+  "slug": "elements/flyout-menus",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "full-width-two-columns",
+      "label": "Full Width Two Columns",
+      "file": "full_width_two_columns.html"
+    },
+    {
+      "id": "full-width",
+      "label": "Full Width",
+      "file": "full_width.html"
+    },
+    {
+      "id": "simple-with-descriptions",
+      "label": "Simple With Descriptions",
+      "file": "simple_with_descriptions.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "stacked-with-footer-actions",
+      "label": "Stacked With Footer Actions",
+      "file": "stacked_with_footer_actions.html"
+    },
+    {
+      "id": "stacked-with-footer-list",
+      "label": "Stacked With Footer List",
+      "file": "stacked_with_footer_list.html"
+    },
+    {
+      "id": "two-column",
+      "label": "Two Column",
+      "file": "two_column.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/elements/headers/meta.json
+++ b/src/components/marketing/elements/headers/meta.json
@@ -1,0 +1,69 @@
+{
+  "title": "Elements – Headers",
+  "slug": "elements/headers",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "constrained",
+      "label": "Constrained",
+      "file": "constrained.html"
+    },
+    {
+      "id": "full-width",
+      "label": "Full Width",
+      "file": "full_width.html"
+    },
+    {
+      "id": "on-brand-background",
+      "label": "On Brand Background",
+      "file": "on_brand_background.html"
+    },
+    {
+      "id": "on-dark-background",
+      "label": "On Dark Background",
+      "file": "on_dark_background.html"
+    },
+    {
+      "id": "with-call-to-action",
+      "label": "With Call To Action",
+      "file": "with_call_to_action.html"
+    },
+    {
+      "id": "with-centered-logo",
+      "label": "With Centered Logo",
+      "file": "with_centered_logo.html"
+    },
+    {
+      "id": "with-full-width-flyout-menu",
+      "label": "With Full Width Flyout Menu",
+      "file": "with_full_width_flyout_menu.html"
+    },
+    {
+      "id": "with-icons-in-mobile-menu",
+      "label": "With Icons In Mobile Menu",
+      "file": "with_icons_in_mobile_menu.html"
+    },
+    {
+      "id": "with-left-aligned-nav",
+      "label": "With Left Aligned Nav",
+      "file": "with_left_aligned_nav.html"
+    },
+    {
+      "id": "with-multiple-flyout-menus",
+      "label": "With Multiple Flyout Menus",
+      "file": "with_multiple_flyout_menus.html"
+    },
+    {
+      "id": "with-right-aligned-nav",
+      "label": "With Right Aligned Nav",
+      "file": "with_right_aligned_nav.html"
+    },
+    {
+      "id": "with-stacked-flyout-menu",
+      "label": "With Stacked Flyout Menu",
+      "file": "with_stacked_flyout_menu.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/feedback/404-pages/meta.json
+++ b/src/components/marketing/feedback/404-pages/meta.json
@@ -1,0 +1,34 @@
+{
+  "title": "Feedback – 404 Pages",
+  "slug": "feedback/404-pages",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "split-with-image",
+      "label": "Split With Image",
+      "file": "split_with_image.html"
+    },
+    {
+      "id": "with-background-image",
+      "label": "With Background Image",
+      "file": "with_background_image.html"
+    },
+    {
+      "id": "with-navbar-and-footer",
+      "label": "With Navbar And Footer",
+      "file": "with_navbar_and_footer.html"
+    },
+    {
+      "id": "with-popular-pages",
+      "label": "With Popular Pages",
+      "file": "with_popular_pages.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/page-examples/about-pages/meta.json
+++ b/src/components/marketing/page-examples/about-pages/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Page Examples – About Pages",
+  "slug": "page-examples/about-pages",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "dark",
+      "label": "Dark",
+      "file": "dark.html"
+    },
+    {
+      "id": "with-image-tiles",
+      "label": "With Image Tiles",
+      "file": "with_image_tiles.html"
+    },
+    {
+      "id": "with-timeline-and-stats",
+      "label": "With Timeline And Stats",
+      "file": "with_timeline_and_stats.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/page-examples/landing-pages/meta.json
+++ b/src/components/marketing/page-examples/landing-pages/meta.json
@@ -1,0 +1,29 @@
+{
+  "title": "Page Examples – Landing Pages",
+  "slug": "page-examples/landing-pages",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-background-image-hero-and-pricing-section",
+      "label": "With Background Image Hero And Pricing Section",
+      "file": "with_background_image_hero_and_pricing_section.html"
+    },
+    {
+      "id": "with-large-screenshot-and-testimonial",
+      "label": "With Large Screenshot And Testimonial",
+      "file": "with_large_screenshot_and_testimonial.html"
+    },
+    {
+      "id": "with-mobile-screenshot-and-testimonials-grid",
+      "label": "With Mobile Screenshot And Testimonials Grid",
+      "file": "with_mobile_screenshot_and_testimonials_grid.html"
+    },
+    {
+      "id": "with-screenshots-and-stats",
+      "label": "With Screenshots And Stats",
+      "file": "with_screenshots_and_stats.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/page-examples/pricing-pages/meta.json
+++ b/src/components/marketing/page-examples/pricing-pages/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Page Examples – Pricing Pages",
+  "slug": "page-examples/pricing-pages",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "with-comparison-table",
+      "label": "With Comparison Table",
+      "file": "with_comparison_table.html"
+    },
+    {
+      "id": "with-four-tiers",
+      "label": "With Four Tiers",
+      "file": "with_four_tiers.html"
+    },
+    {
+      "id": "with-three-tiers-and-testimonials",
+      "label": "With Three Tiers And Testimonials",
+      "file": "with_three_tiers_and_testimonials.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/bento-grids/meta.json
+++ b/src/components/marketing/sections/bento-grids/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Sections – Bento Grids",
+  "slug": "sections/bento-grids",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "three-column-bento-grid",
+      "label": "Three Column Bento Grid",
+      "file": "three_column_bento_grid.html"
+    },
+    {
+      "id": "two-row-bento-grid-on-dark",
+      "label": "Two Row Bento Grid On Dark",
+      "file": "two_row_bento_grid_on_dark.html"
+    },
+    {
+      "id": "two-row-bento-grid",
+      "label": "Two Row Bento Grid",
+      "file": "two_row_bento_grid.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/blog-sections/meta.json
+++ b/src/components/marketing/sections/blog-sections/meta.json
@@ -1,0 +1,44 @@
+{
+  "title": "Sections – Blog Sections",
+  "slug": "sections/blog-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "single-column-with-images",
+      "label": "Single Column With Images",
+      "file": "single_column_with_images.html"
+    },
+    {
+      "id": "single-column",
+      "label": "Single Column",
+      "file": "single_column.html"
+    },
+    {
+      "id": "three-column-with-background-images",
+      "label": "Three Column With Background Images",
+      "file": "three_column_with_background_images.html"
+    },
+    {
+      "id": "three-column-with-images",
+      "label": "Three Column With Images",
+      "file": "three_column_with_images.html"
+    },
+    {
+      "id": "three-column",
+      "label": "Three Column",
+      "file": "three_column.html"
+    },
+    {
+      "id": "with-featured-post",
+      "label": "With Featured Post",
+      "file": "with_featured_post.html"
+    },
+    {
+      "id": "with-photo-and-list",
+      "label": "With Photo And List",
+      "file": "with_photo_and_list.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/contact-sections/meta.json
+++ b/src/components/marketing/sections/contact-sections/meta.json
@@ -1,0 +1,49 @@
+{
+  "title": "Sections – Contact Sections",
+  "slug": "sections/contact-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "centered",
+      "label": "Centered",
+      "file": "centered.html"
+    },
+    {
+      "id": "side-by-side-grid",
+      "label": "Side By Side Grid",
+      "file": "side_by_side_grid.html"
+    },
+    {
+      "id": "simple-centered",
+      "label": "Simple Centered",
+      "file": "simple_centered.html"
+    },
+    {
+      "id": "simple-four-column",
+      "label": "Simple Four Column",
+      "file": "simple_four_column.html"
+    },
+    {
+      "id": "split-with-image",
+      "label": "Split With Image",
+      "file": "split_with_image.html"
+    },
+    {
+      "id": "split-with-pattern-on-dark",
+      "label": "Split With Pattern On Dark",
+      "file": "split_with_pattern_on_dark.html"
+    },
+    {
+      "id": "split-with-pattern",
+      "label": "Split With Pattern",
+      "file": "split_with_pattern.html"
+    },
+    {
+      "id": "with-testimonial",
+      "label": "With Testimonial",
+      "file": "with_testimonial.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/content-sections/meta.json
+++ b/src/components/marketing/sections/content-sections/meta.json
@@ -1,0 +1,44 @@
+{
+  "title": "Sections – Content Sections",
+  "slug": "sections/content-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "centered",
+      "label": "Centered",
+      "file": "centered.html"
+    },
+    {
+      "id": "split-with-image",
+      "label": "Split With Image",
+      "file": "split_with_image.html"
+    },
+    {
+      "id": "two-columns-with-screenshot",
+      "label": "Two Columns With Screenshot",
+      "file": "two_columns_with_screenshot.html"
+    },
+    {
+      "id": "with-image-titles",
+      "label": "With Image Titles",
+      "file": "with_image_titles.html"
+    },
+    {
+      "id": "with-sticky-product-screenshot",
+      "label": "With Sticky Product Screenshot",
+      "file": "with_sticky_product_screenshot.html"
+    },
+    {
+      "id": "with-testimonial-and-stats",
+      "label": "With Testimonial And Stats",
+      "file": "with_testimonial_and_stats.html"
+    },
+    {
+      "id": "with-testimonial",
+      "label": "With Testimonial",
+      "file": "with_testimonial.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/cta-sections/meta.json
+++ b/src/components/marketing/sections/cta-sections/meta.json
@@ -1,0 +1,64 @@
+{
+  "title": "Sections – CTA Sections",
+  "slug": "sections/cta-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "centered-on-dark-panel",
+      "label": "Centered On Dark Panel",
+      "file": "centered_on_dark_panel.html"
+    },
+    {
+      "id": "dark-panel-with-app-screenshot",
+      "label": "Dark Panel With App Screenshot",
+      "file": "dark_panel_with_app_screenshot.html"
+    },
+    {
+      "id": "simple-centered-on-brand",
+      "label": "Simple Centered On Brand",
+      "file": "simple_centered_on_brand.html"
+    },
+    {
+      "id": "simple-centered-on-dark",
+      "label": "Simple Centered On Dark",
+      "file": "simple_centered_on_dark.html"
+    },
+    {
+      "id": "simple-centered",
+      "label": "Simple Centered",
+      "file": "simple_centered.html"
+    },
+    {
+      "id": "simple-justified-on-light-brand",
+      "label": "Simple Justified On Light Brand",
+      "file": "simple_justified_on_light_brand.html"
+    },
+    {
+      "id": "simple-justified",
+      "label": "Simple Justified",
+      "file": "simple_justified.html"
+    },
+    {
+      "id": "simple-stacked",
+      "label": "Simple Stacked",
+      "file": "simple_stacked.html"
+    },
+    {
+      "id": "split-with-image",
+      "label": "Split With Image",
+      "file": "split_with_image.html"
+    },
+    {
+      "id": "two-columns-with-photo-on-dark",
+      "label": "Two Columns With Photo On Dark",
+      "file": "two_columns_with_photo_on_dark.html"
+    },
+    {
+      "id": "with-image-tiles",
+      "label": "With Image Tiles",
+      "file": "with_image_tiles.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/faq-sections/meta.json
+++ b/src/components/marketing/sections/faq-sections/meta.json
@@ -1,0 +1,59 @@
+{
+  "title": "Sections – FAQ Sections",
+  "slug": "sections/faq-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "centered-accordion-on-dark",
+      "label": "Centered Accordion On Dark",
+      "file": "centered_accordion_on_dark.html"
+    },
+    {
+      "id": "centered-accordion",
+      "label": "Centered Accordion",
+      "file": "centered_accordion.html"
+    },
+    {
+      "id": "offset-with-supporting-text",
+      "label": "Offset With Supporting Text",
+      "file": "offset_with_supporting_text.html"
+    },
+    {
+      "id": "side-by-side",
+      "label": "Side By Side",
+      "file": "side_by_side.html"
+    },
+    {
+      "id": "three-columns-on-dark",
+      "label": "Three Columns On Dark",
+      "file": "three_columns_on_dark.html"
+    },
+    {
+      "id": "three-columns-with-centered-introduction",
+      "label": "Three Columns With Centered Introduction",
+      "file": "three_columns_with_centered_introduction.html"
+    },
+    {
+      "id": "three-columns",
+      "label": "Three Columns",
+      "file": "three_columns.html"
+    },
+    {
+      "id": "two-columns-on-dark",
+      "label": "Two Columns On Dark",
+      "file": "two_columns_on_dark.html"
+    },
+    {
+      "id": "two-columns-with-centered-introduction",
+      "label": "Two Columns With Centered Introduction",
+      "file": "two_columns_with_centered_introduction.html"
+    },
+    {
+      "id": "two-columns",
+      "label": "Two Columns",
+      "file": "two_columns.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/feature-sections/meta.json
+++ b/src/components/marketing/sections/feature-sections/meta.json
@@ -1,0 +1,109 @@
+{
+  "title": "Sections – Feature Sections",
+  "slug": "sections/feature-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "centered-2x2-grid",
+      "label": "Centered 2x2 Grid",
+      "file": "centered_2x2_grid.html"
+    },
+    {
+      "id": "contained-in-panel",
+      "label": "Contained In Panel",
+      "file": "contained_in_panel.html"
+    },
+    {
+      "id": "offset-2x2-grid",
+      "label": "Offset 2x2 Grid",
+      "file": "offset_2x2_grid.html"
+    },
+    {
+      "id": "offset-with-feature-list",
+      "label": "Offset With Feature List",
+      "file": "offset_with_feature_list.html"
+    },
+    {
+      "id": "simple-3x2-on-dark",
+      "label": "Simple 3x2 On Dark",
+      "file": "simple_3x2_on_dark.html"
+    },
+    {
+      "id": "simple-three-column-with-large-icons-on-dark",
+      "label": "Simple Three Column With Large Icons On Dark",
+      "file": "simple_three_column_with_large_icons_on_dark.html"
+    },
+    {
+      "id": "simple-three-column-with-large-icons",
+      "label": "Simple Three Column With Large Icons",
+      "file": "simple_three_column_with_large_icons.html"
+    },
+    {
+      "id": "simple-three-column-with-small-icons-on-dark",
+      "label": "Simple Three Column With Small Icons On Dark",
+      "file": "simple_three_column_with_small_icons_on_dark.html"
+    },
+    {
+      "id": "simple-three-column-with-small-icons",
+      "label": "Simple Three Column With Small Icons",
+      "file": "simple_three_column_with_small_icons.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-code-example-panel",
+      "label": "With Code Example Panel",
+      "file": "with_code_example_panel.html"
+    },
+    {
+      "id": "with-large-bordered-screenshot-on-dark",
+      "label": "With Large Bordered Screenshot On Dark",
+      "file": "with_large_bordered_screenshot_on_dark.html"
+    },
+    {
+      "id": "with-large-bordered-screenshot",
+      "label": "With Large Bordered Screenshot",
+      "file": "with_large_bordered_screenshot.html"
+    },
+    {
+      "id": "with-large-screenshot-on-dark",
+      "label": "With Large Screenshot On Dark",
+      "file": "with_large_screenshot_on_dark.html"
+    },
+    {
+      "id": "with-large-screenshot",
+      "label": "With Large Screenshot",
+      "file": "with_large_screenshot.html"
+    },
+    {
+      "id": "with-product-screenshot-on-dark",
+      "label": "With Product Screenshot On Dark",
+      "file": "with_product_screenshot_on_dark.html"
+    },
+    {
+      "id": "with-product-screenshot-on-left",
+      "label": "With Product Screenshot On Left",
+      "file": "with_product_screenshot_on_left.html"
+    },
+    {
+      "id": "with-product-screenshot-panel",
+      "label": "With Product Screenshot Panel",
+      "file": "with_product_screenshot_panel.html"
+    },
+    {
+      "id": "with-product-screenshot",
+      "label": "With Product Screenshot",
+      "file": "with_product_screenshot.html"
+    },
+    {
+      "id": "with-testimonial",
+      "label": "With Testimonial",
+      "file": "with_testimonial.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/footers/meta.json
+++ b/src/components/marketing/sections/footers/meta.json
@@ -1,0 +1,79 @@
+{
+  "title": "Sections – Footers",
+  "slug": "sections/footers",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "4-column-simple-on-dark",
+      "label": "4 Column Simple On Dark",
+      "file": "4_column_simple_on_dark.html"
+    },
+    {
+      "id": "4-column-simple",
+      "label": "4 Column Simple",
+      "file": "4_column_simple.html"
+    },
+    {
+      "id": "4-column-with-call-to-action-on-dark",
+      "label": "4 Column With Call To Action On Dark",
+      "file": "4_column_with_call_to_action_on_dark.html"
+    },
+    {
+      "id": "4-column-with-call-to-action",
+      "label": "4 Column With Call To Action",
+      "file": "4_column_with_call_to_action.html"
+    },
+    {
+      "id": "4-column-with-company-mission-on-dark",
+      "label": "4 Column With Company Mission On Dark",
+      "file": "4_column_with_company_mission_on_dark.html"
+    },
+    {
+      "id": "4-column-with-company-mission",
+      "label": "4 Column With Company Mission",
+      "file": "4_column_with_company_mission.html"
+    },
+    {
+      "id": "4-column-with-newsletter-below-on-dark",
+      "label": "4 Column With Newsletter Below On Dark",
+      "file": "4_column_with_newsletter_below_on_dark.html"
+    },
+    {
+      "id": "4-column-with-newsletter-below",
+      "label": "4 Column With Newsletter Below",
+      "file": "4_column_with_newsletter_below.html"
+    },
+    {
+      "id": "4-column-with-newsletter-on-dark",
+      "label": "4 Column With Newsletter On Dark",
+      "file": "4_column_with_newsletter_on_dark.html"
+    },
+    {
+      "id": "4-column-with-newsletter",
+      "label": "4 Column With Newsletter",
+      "file": "4_column_with_newsletter.html"
+    },
+    {
+      "id": "simple-centered-on-dark",
+      "label": "Simple Centered On Dark",
+      "file": "simple_centered_on_dark.html"
+    },
+    {
+      "id": "simple-centered",
+      "label": "Simple Centered",
+      "file": "simple_centered.html"
+    },
+    {
+      "id": "simple-with-social-links-on-dark",
+      "label": "Simple With Social Links On Dark",
+      "file": "simple_with_social_links_on_dark.html"
+    },
+    {
+      "id": "simple-with-social-links",
+      "label": "Simple With Social Links",
+      "file": "simple_with_social_links.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/header/meta.json
+++ b/src/components/marketing/sections/header/meta.json
@@ -1,0 +1,59 @@
+{
+  "title": "Sections – Header",
+  "slug": "sections/header",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "centered-on-dark",
+      "label": "Centered On Dark",
+      "file": "centered_on_dark.html"
+    },
+    {
+      "id": "centered-with-background-image",
+      "label": "Centered With Background Image",
+      "file": "centered_with_background_image.html"
+    },
+    {
+      "id": "centered-with-eyebrow",
+      "label": "Centered With Eyebrow",
+      "file": "centered_with_eyebrow.html"
+    },
+    {
+      "id": "centered",
+      "label": "Centered",
+      "file": "centered.html"
+    },
+    {
+      "id": "simple-on-dark",
+      "label": "Simple On Dark",
+      "file": "simple_on_dark.html"
+    },
+    {
+      "id": "simple-with-background-image",
+      "label": "Simple With Background Image",
+      "file": "simple_with_background_image.html"
+    },
+    {
+      "id": "simple-with-eyebrow",
+      "label": "Simple With Eyebrow",
+      "file": "simple_with_eyebrow.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "with-cards",
+      "label": "With Cards",
+      "file": "with_cards.html"
+    },
+    {
+      "id": "with-stats",
+      "label": "With Stats",
+      "file": "with_stats.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/heroes/meta.json
+++ b/src/components/marketing/sections/heroes/meta.json
@@ -1,0 +1,69 @@
+{
+  "title": "Sections – Heroes",
+  "slug": "sections/heroes",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-centered-with-background-image",
+      "label": "Simple Centered With Background Image",
+      "file": "simple_centered_with_background_image.html"
+    },
+    {
+      "id": "simple-centered",
+      "label": "Simple Centered",
+      "file": "simple_centered.html"
+    },
+    {
+      "id": "split-with-code-example",
+      "label": "Split With Code Example",
+      "file": "split_with_code_example.html"
+    },
+    {
+      "id": "split-with-image",
+      "label": "Split With Image",
+      "file": "split_with_image.html"
+    },
+    {
+      "id": "split-with-screenshot-on-dark",
+      "label": "Split With Screenshot On Dark",
+      "file": "split_with_screenshot_on_dark.html"
+    },
+    {
+      "id": "split-with-screenshot",
+      "label": "Split With Screenshot",
+      "file": "split_with_screenshot.html"
+    },
+    {
+      "id": "with-angled-image-on-right",
+      "label": "With Angled Image On Right",
+      "file": "with_angled_image_on_right.html"
+    },
+    {
+      "id": "with-app-screenshot-on-dark",
+      "label": "With App Screenshot On Dark",
+      "file": "with_app_screenshot_on_dark.html"
+    },
+    {
+      "id": "with-app-screenshot",
+      "label": "With App Screenshot",
+      "file": "with_app_screenshot.html"
+    },
+    {
+      "id": "with-image-tiles",
+      "label": "With Image Tiles",
+      "file": "with_image_tiles.html"
+    },
+    {
+      "id": "with-offset-image",
+      "label": "With Offset Image",
+      "file": "with_offset_image.html"
+    },
+    {
+      "id": "with-phone-mockup",
+      "label": "With Phone Mockup",
+      "file": "with_phone_mockup.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/logo-clouds/meta.json
+++ b/src/components/marketing/sections/logo-clouds/meta.json
@@ -1,0 +1,69 @@
+{
+  "title": "Sections – Logo Clouds",
+  "slug": "sections/logo-clouds",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "grid-on-dark",
+      "label": "Grid On Dark",
+      "file": "grid_on_dark.html"
+    },
+    {
+      "id": "grid",
+      "label": "Grid",
+      "file": "grid.html"
+    },
+    {
+      "id": "simple-left-aligned-on-dark",
+      "label": "Simple Left Aligned On Dark",
+      "file": "simple_left_aligned_on_dark.html"
+    },
+    {
+      "id": "simple-left-aligned",
+      "label": "Simple Left Aligned",
+      "file": "simple_left_aligned.html"
+    },
+    {
+      "id": "simple-on-dark",
+      "label": "Simple On Dark",
+      "file": "simple_on_dark.html"
+    },
+    {
+      "id": "simple-with-call-to-action-on-dark",
+      "label": "Simple With Call To Action On Dark",
+      "file": "simple_with_call_to_action_on_dark.html"
+    },
+    {
+      "id": "simple-with-call-to-action",
+      "label": "Simple With Call To Action",
+      "file": "simple_with_call_to_action.html"
+    },
+    {
+      "id": "simple-with-heading-on-dark",
+      "label": "Simple With Heading On Dark",
+      "file": "simple_with_heading_on_dark.html"
+    },
+    {
+      "id": "simple-with-heading",
+      "label": "Simple With Heading",
+      "file": "simple_with_heading.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "split-with-logos-on-right-on-dark",
+      "label": "Split With Logos On Right On Dark",
+      "file": "split_with_logos_on_right_on_dark.html"
+    },
+    {
+      "id": "split-with-logos-on-right",
+      "label": "Split With Logos On Right",
+      "file": "split_with_logos_on_right.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/newsletter-sections/meta.json
+++ b/src/components/marketing/sections/newsletter-sections/meta.json
@@ -1,0 +1,44 @@
+{
+  "title": "Sections – Newsletter Sections",
+  "slug": "sections/newsletter-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "centered-card",
+      "label": "Centered Card",
+      "file": "centered_card.html"
+    },
+    {
+      "id": "side-by-side-on-card",
+      "label": "Side By Side On Card",
+      "file": "side_by_side_on_card.html"
+    },
+    {
+      "id": "side-by-side-with-details",
+      "label": "Side By Side With Details",
+      "file": "side_by_side_with_details.html"
+    },
+    {
+      "id": "simple-side-by-side-on-brand",
+      "label": "Simple Side By Side On Brand",
+      "file": "simple_side_by_side_on_brand.html"
+    },
+    {
+      "id": "simple-side-by-side-on-dark",
+      "label": "Simple Side By Side On Dark",
+      "file": "simple_side_by_side_on_dark.html"
+    },
+    {
+      "id": "simple-side-by-side",
+      "label": "Simple Side By Side",
+      "file": "simple_side_by_side.html"
+    },
+    {
+      "id": "simple-stacked",
+      "label": "Simple Stacked",
+      "file": "simple_stacked.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/pricing/meta.json
+++ b/src/components/marketing/sections/pricing/meta.json
@@ -1,0 +1,79 @@
+{
+  "title": "Sections – Pricing",
+  "slug": "sections/pricing",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "four-tiers-with-toggle",
+      "label": "Four Tiers With Toggle",
+      "file": "four_tiers_with_toggle.html"
+    },
+    {
+      "id": "single-price-with-details",
+      "label": "Single Price With Details",
+      "file": "single_price_with_details.html"
+    },
+    {
+      "id": "three-tiers-with-dividers",
+      "label": "Three Tiers With Dividers",
+      "file": "three_tiers_with_dividers.html"
+    },
+    {
+      "id": "three-tiers-with-emphasized-tier",
+      "label": "Three Tiers With Emphasized Tier",
+      "file": "three_tiers_with_emphasized_tier.html"
+    },
+    {
+      "id": "three-tiers-with-feature-comparison",
+      "label": "Three Tiers With Feature Comparison",
+      "file": "three_tiers_with_feature_comparison.html"
+    },
+    {
+      "id": "three-tiers-with-logos-and-feature-comparison",
+      "label": "Three Tiers With Logos And Feature Comparison",
+      "file": "three_tiers_with_logos_and_feature_comparison.html"
+    },
+    {
+      "id": "three-tiers-with-toggle-on-dark",
+      "label": "Three Tiers With Toggle On Dark",
+      "file": "three_tiers_with_toggle_on_dark.html"
+    },
+    {
+      "id": "three-tiers-with-toggle",
+      "label": "Three Tiers With Toggle",
+      "file": "three_tiers_with_toggle.html"
+    },
+    {
+      "id": "three-tiers",
+      "label": "Three Tiers",
+      "file": "three_tiers.html"
+    },
+    {
+      "id": "two-tiers-with-emphasized-tier",
+      "label": "Two Tiers With Emphasized Tier",
+      "file": "two_tiers_with_emphasized_tier.html"
+    },
+    {
+      "id": "two-tiers-with-extra-tier",
+      "label": "Two Tiers With Extra Tier",
+      "file": "two_tiers_with_extra_tier.html"
+    },
+    {
+      "id": "two-tiers",
+      "label": "Two Tiers",
+      "file": "two_tiers.html"
+    },
+    {
+      "id": "with-comparison-table-on-dark",
+      "label": "With Comparison Table On Dark",
+      "file": "with_comparison_table_on_dark.html"
+    },
+    {
+      "id": "with-comparison-table",
+      "label": "With Comparison Table",
+      "file": "with_comparison_table.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/stats-sections/meta.json
+++ b/src/components/marketing/sections/stats-sections/meta.json
@@ -1,0 +1,59 @@
+{
+  "title": "Sections – Stats Sections",
+  "slug": "sections/stats-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "simple-grid-on-dark",
+      "label": "Simple Grid On Dark",
+      "file": "simple_grid_on_dark.html"
+    },
+    {
+      "id": "simple-grid",
+      "label": "Simple Grid",
+      "file": "simple_grid.html"
+    },
+    {
+      "id": "simple-on-dark",
+      "label": "Simple On Dark",
+      "file": "simple_on_dark.html"
+    },
+    {
+      "id": "simple",
+      "label": "Simple",
+      "file": "simple.html"
+    },
+    {
+      "id": "split-with-image",
+      "label": "Split With Image",
+      "file": "split_with_image.html"
+    },
+    {
+      "id": "stepped",
+      "label": "Stepped",
+      "file": "stepped.html"
+    },
+    {
+      "id": "timeline",
+      "label": "Timeline",
+      "file": "timeline.html"
+    },
+    {
+      "id": "with-background-image",
+      "label": "With Background Image",
+      "file": "with_background_image.html"
+    },
+    {
+      "id": "with-description",
+      "label": "With Description",
+      "file": "with_description.html"
+    },
+    {
+      "id": "with-two-column-description-on-dark",
+      "label": "With Two Column Description On Dark",
+      "file": "with_two_column_description_on_dark.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/team-sections/meta.json
+++ b/src/components/marketing/sections/team-sections/meta.json
@@ -1,0 +1,54 @@
+{
+  "title": "Sections – Team Sections",
+  "slug": "sections/team-sections",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "dark-version-with-large-images",
+      "label": "Dark Version With Large Images",
+      "file": "dark_version_with_large_images.html"
+    },
+    {
+      "id": "full-width-with-vertical-images",
+      "label": "Full Width With Vertical Images",
+      "file": "full_width_with_vertical_images.html"
+    },
+    {
+      "id": "grid-with-large-round-images",
+      "label": "Grid With Large Round Images",
+      "file": "grid_with_large_round_images.html"
+    },
+    {
+      "id": "grid-with-round-images",
+      "label": "Grid With Round Images",
+      "file": "grid_with_round_images.html"
+    },
+    {
+      "id": "with-image-and-short-paragraph",
+      "label": "With Image And Short Paragraph",
+      "file": "with_image_and_short_paragraph.html"
+    },
+    {
+      "id": "with-large-images",
+      "label": "With Large Images",
+      "file": "with_large_images.html"
+    },
+    {
+      "id": "with-medium-images-on-dark",
+      "label": "With Medium Images On Dark",
+      "file": "with_medium_images_on_dark.html"
+    },
+    {
+      "id": "with-small-images",
+      "label": "With Small Images",
+      "file": "with_small_images.html"
+    },
+    {
+      "id": "with-vertical-images",
+      "label": "With Vertical Images",
+      "file": "with_vertical_images.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/components/marketing/sections/testimonials/meta.json
+++ b/src/components/marketing/sections/testimonials/meta.json
@@ -1,0 +1,54 @@
+{
+  "title": "Sections – Testimonials",
+  "slug": "sections/testimonials",
+  "category": "marketing",
+  "tags": [],
+  "variants": [
+    {
+      "id": "grid",
+      "label": "Grid",
+      "file": "grid.html"
+    },
+    {
+      "id": "off-white-grid",
+      "label": "Off White Grid",
+      "file": "off_white_grid.html"
+    },
+    {
+      "id": "side-by-side-on-dark",
+      "label": "Side By Side On Dark",
+      "file": "side_by_side_on_dark.html"
+    },
+    {
+      "id": "side-by-side",
+      "label": "Side By Side",
+      "file": "side_by_side.html"
+    },
+    {
+      "id": "simple-centered",
+      "label": "Simple Centered",
+      "file": "simple_centered.html"
+    },
+    {
+      "id": "with-background-image",
+      "label": "With Background Image",
+      "file": "with_background_image.html"
+    },
+    {
+      "id": "with-large-avatar",
+      "label": "With Large Avatar",
+      "file": "with_large_avatar.html"
+    },
+    {
+      "id": "with-overlapping-image",
+      "label": "With Overlapping Image",
+      "file": "with_overlapping_image.html"
+    },
+    {
+      "id": "with-star-rating",
+      "label": "With Star Rating",
+      "file": "with_star_rating.html"
+    }
+  ],
+  "props": {}
+}

--- a/src/core/sandbox.js
+++ b/src/core/sandbox.js
@@ -1,12 +1,61 @@
 // /src/core/sandbox.js
-export async function renderInSandbox(
+const MIN_IFRAME_HEIGHT = 320;
+
+export function renderInSandbox(
   iframe,
   html,
   { dark = false, alpine = false } = {},
 ) {
-  const doc = iframe.contentDocument;
-  doc.open();
-  doc.write(`<!doctype html>
+  if (iframe.__sandboxObserver) {
+    iframe.__sandboxObserver.disconnect();
+    iframe.__sandboxObserver = null;
+  }
+
+  iframe.style.height = `${MIN_IFRAME_HEIGHT}px`;
+
+  return new Promise((resolve) => {
+    const handleLoad = () => {
+      iframe.removeEventListener("load", handleLoad);
+
+      try {
+        const doc = iframe.contentDocument;
+        const win = iframe.contentWindow;
+        if (!doc || !win) {
+          resolve();
+          return;
+        }
+
+        const adjustHeight = () => {
+          const docEl = doc.documentElement;
+          const body = doc.body;
+          const nextHeight = Math.max(
+            MIN_IFRAME_HEIGHT,
+            docEl?.scrollHeight ?? 0,
+            body?.scrollHeight ?? 0,
+            docEl?.offsetHeight ?? 0,
+            body?.offsetHeight ?? 0,
+          );
+          iframe.style.height = `${nextHeight}px`;
+        };
+
+        adjustHeight();
+
+        if (typeof win.ResizeObserver === "function") {
+          const ro = new win.ResizeObserver(() => adjustHeight());
+          ro.observe(doc.documentElement);
+          ro.observe(doc.body);
+          iframe.__sandboxObserver = ro;
+        }
+      } finally {
+        resolve();
+      }
+    };
+
+    iframe.addEventListener("load", handleLoad, { once: true });
+
+    const doc = iframe.contentDocument;
+    doc.open();
+    doc.write(`<!doctype html>
 <html lang="en" class="${dark ? "dark" : ""}">
 <head>
   <meta charset="utf-8" />
@@ -15,14 +64,21 @@ export async function renderInSandbox(
   <script src="https://cdn.tailwindcss.com"></script>
   ${alpine ? '<script defer src="https://unpkg.com/alpinejs"></script>' : ""}
   <style>
-    /* Giúp nội dung tự co theo khung, tránh tràn */
-    html, body { height: 100%; }
-    body { margin: 0; background: #f4f4f5; }
+    :root {
+      color-scheme: light dark;
+    }
+    html, body { min-height: 100%; }
+    body {
+      margin: 0;
+      background: ${dark ? "#09090b" : "#f4f4f5"};
+      transition: background-color 150ms ease;
+    }
   </style>
 </head>
 <body class="min-h-dvh p-4">
 ${html}
 </body>
 </html>`);
-  doc.close();
+    doc.close();
+  });
 }

--- a/src/ui/Viewer.js
+++ b/src/ui/Viewer.js
@@ -73,8 +73,11 @@ export async function showViewer(category, slug) {
           <!-- vùng cuộn ngang -->
           <div id="scroll-${v.id}" class="overflow-x-auto">
             <!-- khung bọc có width đúng bằng iframe để cuộn -->
-            <div id="wrap-${v.id}" class="inline-block">
-              <iframe id="pv-${v.id}" class="block h-[420px] bg-white rounded shadow-sm"></iframe>
+            <div id="wrap-${v.id}" class="block">
+              <iframe
+                id="pv-${v.id}"
+                class="block min-h-[320px] w-full bg-white rounded shadow-sm transition-[width] duration-200"
+              ></iframe>
             </div>
           </div>
 
@@ -122,16 +125,19 @@ export async function showViewer(category, slug) {
 
     // Device widths — đổi width của CHÍNH iframe ✅
     function applyWidth(size) {
-      // ✅ CHANGED
       if (size === "full") {
-        iframe.style.width = "1280px";
-        wrap.style.maxWidth = "none";
+        iframe.style.width = "100%";
+        iframe.style.maxWidth = "100%";
+        wrap.style.width = "100%";
+        wrap.style.maxWidth = "100%";
         wrap.style.marginLeft = "";
         wrap.style.marginRight = "";
       } else {
         const px = String(size).endsWith("px") ? String(size) : `${size}px`;
-        iframe.style.width = px; // ✅ CHANGED
-        wrap.style.maxWidth = px; // center cho gọn
+        iframe.style.width = px;
+        iframe.style.maxWidth = "100%";
+        wrap.style.width = px;
+        wrap.style.maxWidth = "100%";
         wrap.style.marginLeft = "auto";
         wrap.style.marginRight = "auto";
       }


### PR DESCRIPTION
## Summary
- tune the component viewer markup so iframe previews default to responsive full width and smoother width transitions
- update the sandbox renderer to auto-resize iframe height with a ResizeObserver and theme-aware background styles for light and dark modes

## Testing
- `npm run build` *(fails: Cannot find package '@tailwindcss/vite' imported from vite config)*

------
https://chatgpt.com/codex/tasks/task_e_68dca7bcfa4c8330bc28eef45b2a3de7