### PR TITLE
Simplify sandbox iframe rendering and variant controls

### DIFF
--- a/src/core/sandbox.js
+++ b/src/core/sandbox.js
@@ -26,8 +26,7 @@ export function renderInSandbox(
         }
 
         const adjustHeight = () => {
-          const docEl = doc.documentElement;
-          const body = doc.body;
+          const { documentElement: docEl, body } = doc;
           const nextHeight = Math.max(
             MIN_IFRAME_HEIGHT,
             docEl?.scrollHeight ?? 0,
@@ -41,7 +40,7 @@ export function renderInSandbox(
         adjustHeight();
 
         if (typeof win.ResizeObserver === "function") {
-          const ro = new win.ResizeObserver(() => adjustHeight());
+          const ro = new win.ResizeObserver(adjustHeight);
           ro.observe(doc.documentElement);
           ro.observe(doc.body);
           iframe.__sandboxObserver = ro;
@@ -53,14 +52,11 @@ export function renderInSandbox(
 
     iframe.addEventListener("load", handleLoad, { once: true });
 
-    const doc = iframe.contentDocument;
-    doc.open();
-    doc.write(`<!doctype html>
+    iframe.srcdoc = `<!doctype html>
 <html lang="en" class="${dark ? "dark" : ""}">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- Dùng Tailwind CDN trong iframe để đảm bảo breakpoints -->
   <script src="https://cdn.tailwindcss.com"></script>
   ${alpine ? '<script defer src="https://unpkg.com/alpinejs"></script>' : ""}
   <style>
@@ -78,7 +74,6 @@ export function renderInSandbox(
 <body class="min-h-dvh p-4">
 ${html}
 </body>
-</html>`);
-    doc.close();
+</html>`;
   });
 }

--- a/src/ui/Viewer.js
+++ b/src/ui/Viewer.js
@@ -40,50 +40,50 @@ export async function showViewer(category, slug) {
       ${meta.variants
         .map(
           (v) => `
-      <section class="border rounded overflow-hidden">
+      <section class="border rounded overflow-hidden" data-variant="${v.id}">
         <header class="flex items-center justify-between px-3 py-2 border-b">
           <div class="font-medium">${v.label}</div>
           <div class="flex items-center gap-2 text-sm">
             <!-- Segmented: Preview | Code -->
             <div class="inline-flex rounded border overflow-hidden" role="tablist">
-              <button class="px-3 py-1.5" data-tab="${v.id}" data-to="preview">Preview</button>
-              <button class="px-3 py-1.5 border-l" data-tab="${v.id}" data-to="code">Code</button>
+              <button class="px-3 py-1.5" data-tab="preview">Preview</button>
+              <button class="px-3 py-1.5 border-l" data-tab="code">Code</button>
             </div>
             <!-- Device widths -->
             <div class="inline-flex rounded border overflow-hidden">
-              <button class="px-2 py-1.5" title="Mobile" data-w="${v.id}" data-size="480">📱</button>
-              <button class="px-2 py-1.5 border-l" title="Tablet" data-w="${v.id}" data-size="1024">📟</button>
-              <button class="px-2 py-1.5 border-l" title="Desktop" data-w="${v.id}" data-size="1280">🖥️</button>
-              <button class="px-2 py-1.5 border-l" title="Full" data-w="${v.id}" data-size="full">↔</button>
+              <button class="px-2 py-1.5" title="Mobile" data-width="480">📱</button>
+              <button class="px-2 py-1.5 border-l" title="Tablet" data-width="1024">📟</button>
+              <button class="px-2 py-1.5 border-l" title="Desktop" data-width="1280">🖥️</button>
+              <button class="px-2 py-1.5 border-l" title="Full" data-width="full">↔</button>
             </div>
             <!-- Dark -->
-            <button class="px-2 py-1.5 rounded border" data-dark="${v.id}" title="Dark mode">🌙</button>
+            <button class="px-2 py-1.5 rounded border" data-dark-toggle title="Dark mode">🌙</button>
             <!-- Lang -->
-            <select class="px-2 py-1.5 rounded border bg-white" data-lang="${v.id}">
+            <select class="px-2 py-1.5 rounded border bg-white" data-lang>
               <option value="html" selected>HTML</option>
               <option value="react" disabled>React</option>
               <option value="vue" disabled>Vue</option>
             </select>
             <!-- Copy -->
-            <button class="px-2 py-1.5 rounded border" data-copy="${v.id}" title="Copy code">📋</button>
+            <button class="px-2 py-1.5 rounded border" data-copy title="Copy code">📋</button>
           </div>
         </header>
 
         <div class="p-3">
           <!-- vùng cuộn ngang -->
-          <div id="scroll-${v.id}" class="overflow-x-auto">
+          <div class="overflow-x-auto">
             <!-- khung bọc có width đúng bằng iframe để cuộn -->
-            <div id="wrap-${v.id}" class="block">
+            <div class="block" data-wrap>
               <iframe
-                id="pv-${v.id}"
                 class="block min-h-[320px] w-full bg-white rounded shadow-sm transition-[width] duration-200"
+                data-iframe
               ></iframe>
             </div>
           </div>
 
           <!-- Code -->
-          <pre id="box-${v.id}" class="hidden bg-zinc-900 text-zinc-50 p-3 text-sm overflow-auto mt-3 rounded">
-<code id="code-${v.id}">Loading…</code>
+          <pre class="hidden bg-zinc-900 text-zinc-50 p-3 text-sm overflow-auto mt-3 rounded" data-code-box>
+<code data-code>Loading…</code>
           </pre>
         </div>
       </section>
@@ -98,7 +98,8 @@ export async function showViewer(category, slug) {
     const html = await htmlFiles[v.path]();
 
     // Render preview mặc định
-    const iframe = document.getElementById(`pv-${v.id}`);
+    const section = main.querySelector(`[data-variant="${v.id}"]`);
+    const iframe = section.querySelector("[data-iframe]");
     let isDark = false;
     await renderInSandbox(iframe, html, {
       dark: isDark,
@@ -106,21 +107,19 @@ export async function showViewer(category, slug) {
     });
 
     // Hiện code (escaped để an toàn)
-    document.getElementById(`code-${v.id}`).textContent = escapeHtml(html);
+    section.querySelector("[data-code]").textContent = escapeHtml(html);
 
     // Tab switch
-    const wrap = document.getElementById(`wrap-${v.id}`);
-    const codeBox = document.getElementById(`box-${v.id}`);
-    const tabBtns = [...document.querySelectorAll(`[data-tab="${v.id}"]`)];
+    const wrap = section.querySelector("[data-wrap]");
+    const codeBox = section.querySelector("[data-code-box]");
+    const tabBtns = [...section.querySelectorAll("[data-tab]")];
     function switchTab(to) {
       const showPreview = to === "preview";
       wrap.classList.toggle("hidden", !showPreview);
       codeBox.classList.toggle("hidden", showPreview);
-      tabBtns.forEach((b) =>
-        b.classList.toggle("bg-zinc-100", b.dataset.to === to),
-      );
+      tabBtns.forEach((b) => b.classList.toggle("bg-zinc-100", b.dataset.tab === to));
     }
-    tabBtns.forEach((b) => (b.onclick = () => switchTab(b.dataset.to)));
+    tabBtns.forEach((b) => (b.onclick = () => switchTab(b.dataset.tab)));
     switchTab("preview");
 
     // Device widths — đổi width của CHÍNH iframe ✅
@@ -143,12 +142,12 @@ export async function showViewer(category, slug) {
       }
     }
     applyWidth("full");
-    document.querySelectorAll(`[data-w="${v.id}"]`).forEach((b) => {
-      b.onclick = () => applyWidth(b.dataset.size);
+    section.querySelectorAll("[data-width]").forEach((b) => {
+      b.onclick = () => applyWidth(b.dataset.width);
     });
 
     // Dark toggle
-    document.querySelector(`[data-dark="${v.id}"]`).onclick = async () => {
+    section.querySelector("[data-dark-toggle]").onclick = async () => {
       isDark = !isDark;
       await renderInSandbox(iframe, html, {
         dark: isDark,
@@ -157,7 +156,7 @@ export async function showViewer(category, slug) {
     };
 
     // Copy
-    document.querySelector(`[data-copy="${v.id}"]`).onclick = () =>
+    section.querySelector("[data-copy]").onclick = () =>
       navigator.clipboard.writeText(html);
   }
 }


### PR DESCRIPTION
## Summary
- streamline the sandbox renderer by switching to srcdoc and reusing the resize observer callback
- scope viewer controls per variant using data attributes instead of global id lookups
- simplify the viewer markup to match the new scoped selectors

## Testing
- npm run build *(fails: Package path . is not exported from package @tailwindplus/elements)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb05b598c8330ab87e20f2179a132